### PR TITLE
Add retries with different torso angles to low-level move-tcp [DON'T MERGE YET]

### DIFF
--- a/cram_pr2/cram_pr2_projection/src/ik.lisp
+++ b/cram_pr2/cram_pr2_projection/src/ik.lisp
@@ -154,10 +154,15 @@
                        'moveit_msgs-msg:moveiterrorcodes
                        error-code)))))))
 
-(defun call-ik-service (left-or-right cartesian-pose &optional seed-state)
+(defparameter *torso-step* 0.01)
+
+(defun call-ik-service (left-or-right cartesian-pose &key seed-state test-angle torso-angle)
   (declare (type keyword left-or-right)
            (type cl-transforms-stamped:pose-stamped cartesian-pose))
-  (let ((ik-link (get-ik-solver-link left-or-right)))
+  ;; (setf *ee-poses* (cons cartesian-pose *ee-poses*))
+  (let ((ik-link (get-ik-solver-link left-or-right))
+        (dbg-lvl (roslisp:debug-level NIL))) ;; TODO: have to get a real name?
+    (roslisp:set-debug-level NIL 9)
     (handler-case
         (roslisp:with-fields ((response-error-code (val error_code))
                               (joint-state (joint_state solution)))
@@ -165,37 +170,75 @@
               (roslisp:wait-for-service (concatenate 'string
                                                      (getf *ik-service-namespaces* left-or-right)
                                                      "/get_ik_solver_info") 10.0)
-              (roslisp:call-service
-               (concatenate 'string (getf *ik-service-namespaces* left-or-right) "/get_ik")
-               "moveit_msgs/GetPositionIK"
-               (roslisp:make-request
-                "moveit_msgs/GetPositionIK"
-                (:ik_link_name :ik_request) ik-link
-                (:pose_stamped :ik_request) (cl-transforms-stamped:to-msg
-                                             (cram-tf:ensure-pose-in-frame
-                                              cartesian-pose
-                                              cram-tf:*robot-torso-frame*
-                                              :use-zero-time t))
-                (:joint_state :robot_state :ik_request) (or seed-state
-                                                            (make-zero-seed-state left-or-right))
-                (:timeout :ik_request) 1.0)))
+                (roslisp:call-service
+                 (concatenate 'string (getf *ik-service-namespaces* left-or-right) "/get_ik")
+                 "moveit_msgs/GetPositionIK"
+                 (roslisp:make-request
+                  "moveit_msgs/GetPositionIK"
+                  (:ik_link_name :ik_request) ik-link
+                  (:pose_stamped :ik_request) (cl-transforms-stamped:to-msg
+                                               (cram-tf:ensure-pose-in-frame
+                                                cartesian-pose
+                                                cram-tf:*robot-torso-frame*
+                                                :use-zero-time t))
+                  (:joint_state :robot_state :ik_request) (or seed-state
+                                                              (make-zero-seed-state left-or-right))
+                  (:timeout :ik_request) 1.0)))
           (cond ((eql response-error-code
                       (roslisp-msg-protocol:symbol-code
                        'moveit_msgs-msg:moveiterrorcodes
-                       :success)) joint-state)
+                       :success))
+                 (roslisp:set-debug-level NIL dbg-lvl)
+                 (values joint-state test-angle))
                 ((eql response-error-code
                       (roslisp-msg-protocol:symbol-code
                        'moveit_msgs-msg:moveiterrorcodes
                        :no_ik_solution)) nil)
                 (t (error 'simple-error
-                          :format-control "IK service failed: ~a"
-                          :format-arguments (list
-                                             (roslisp-msg-protocol:code-symbol
-                                              'moveit_msgs-msg:moveiterrorcodes
-                                              response-error-code))))))
+                                  :format-control "IK service failed: ~a"
+                                  :format-arguments (list
+                                                     (roslisp-msg-protocol:code-symbol
+                                                      'moveit_msgs-msg:moveiterrorcodes
+                                                      response-error-code))))))
       (simple-error (e)
         (declare (ignore e))
-        (format t "IK service call freaked out. No IK solution found.~%")))))
+        (cut:with-vars-bound (?upper-limit ?lower-limit)
+          (car
+           (prolog:prolog `(and
+                            (cram-robot-interfaces:robot ?robot)
+                            (cram-robot-interfaces:robot-torso-link-joint ?robot ?_ ?torso-joint)
+                            (cram-robot-interfaces:joint-upper-limit ?robot ?torso-joint ?upper-limit)
+                            (cram-robot-interfaces:joint-lower-limit ?robot ?torso-joint ?lower-limit)
+                            )))
+          (if (or (not test-angle) (>= test-angle ?lower-limit))
+              (let* ((cur-torso-angle torso-angle)
+                     (next-test-angle (if test-angle
+                                     (max ?lower-limit (- test-angle *torso-step*))
+                                     ?upper-limit))
+                     (torso-offset (if test-angle (- test-angle cur-torso-angle) 0))
+                     (next-torso-offset (- next-test-angle cur-torso-angle))
+                     (pseudo-pose
+                       (cl-transforms-stamped:pose->pose-stamped
+                        (cl-transforms-stamped:frame-id cartesian-pose)
+                        (cl-transforms-stamped:stamp cartesian-pose)
+                        (cl-transforms:transform-pose (cl-tf:pose->transform cartesian-pose)
+                                                      (cl-transforms:make-pose
+                                                       (cl-transforms:make-3d-vector 0 0 (- torso-offset next-torso-offset))
+                                                       (cl-transforms:make-identity-rotation))))))
+                ;; (format T "Torso angle: ~a Test angle: ~a Offset: ~a~%" cur-torso-angle next-test-angle next-torso-offset)
+                (roslisp:set-debug-level NIL dbg-lvl)
+                (multiple-value-bind (ik-solution result-angle)
+                    (call-ik-service left-or-right pseudo-pose
+                                     :torso-angle torso-angle
+                                     :test-angle next-test-angle)
+                  ;; (format T "Result angle: ~a~%" result-angle)
+                  (when ik-solution
+                    (values ik-solution result-angle))))
+              (format t "IK service call freaked out. No IK solution found.~%");; error
+              ))
+        ))))
+
+
 
 (defun call-fk-service (left-or-right link-names-vector
                         &optional (fk-base-frame "torso_lift_link"))
@@ -260,6 +303,6 @@
          (solution
            (call-ik-service arm
                             ee-pose
-                            seed-state)))
+                            :seed-state seed-state)))
     (when solution
       (list solution))))

--- a/cram_pr2/cram_pr2_projection/src/package.lisp
+++ b/cram_pr2/cram_pr2_projection/src/package.lisp
@@ -42,6 +42,8 @@
    ;; projection-clock
    #:action-duration #:projection-timestamp-function #:execute-as-action
 
+   #:*torso-step*
+
    ;; execute-container-opened execute-container-closed
            ;; execute-park execute-lift execute-grasp execute-put-down execute-pour
            ;; projection-navigation projection-ptu projection-perception

--- a/cram_tutorials/cram_bullet_world_tutorial/src/tutorial.lisp
+++ b/cram_tutorials/cram_bullet_world_tutorial/src/tutorial.lisp
@@ -169,3 +169,34 @@
           (let ((?drop-pose *pose-bottle-1*))
             (place-down ?drop-pose ?perceived-bottle-2 :left))
           (pr2-pp-plans::park-arms))))))
+
+(defparameter *perceived-object* nil)
+
+(defun perceive-bottle ()
+  (proj:with-projection-environment pr2-proj::pr2-bullet-projection-environment
+    (cpl:top-level
+      (setf *perceived-object* (pr2-pp-plans::perceive (desig:an object (type bottle)))))))
+
+(defun move-torso (?angle)
+  (proj:with-projection-environment pr2-proj::pr2-bullet-projection-environment
+    (cpl:top-level
+      (exe:perform
+       (desig:a motion (type moving-torso) (joint-angle ?angle))))))
+
+(defun move-bottle (m)
+  (btr-utils:move-object 'bottle-1
+                         (cl-tf:make-pose
+                          (cl-tf:v+ (cl-tf:origin (btr:object-pose 'bottle-1)) (cl-tf:make-3d-vector 0 m 0))
+                          (cl-tf:orientation (btr:object-pose 'bottle-1)))))
+
+(defun place-bottle ()
+  (proj:with-projection-environment pr2-proj::pr2-bullet-projection-environment
+    (cpl:top-level
+      (let ((?bottle (get-perceived-bottle-desig)))
+        (exe:perform (desig:an action
+                               (type placing)
+                               (object ?bottle)
+                               (arm right)))))))
+
+(defun test ()
+  )

--- a/cram_tutorials/cram_bullet_world_tutorial/src/tutorial.lisp
+++ b/cram_tutorials/cram_bullet_world_tutorial/src/tutorial.lisp
@@ -169,34 +169,3 @@
           (let ((?drop-pose *pose-bottle-1*))
             (place-down ?drop-pose ?perceived-bottle-2 :left))
           (pr2-pp-plans::park-arms))))))
-
-(defparameter *perceived-object* nil)
-
-(defun perceive-bottle ()
-  (proj:with-projection-environment pr2-proj::pr2-bullet-projection-environment
-    (cpl:top-level
-      (setf *perceived-object* (pr2-pp-plans::perceive (desig:an object (type bottle)))))))
-
-(defun move-torso (?angle)
-  (proj:with-projection-environment pr2-proj::pr2-bullet-projection-environment
-    (cpl:top-level
-      (exe:perform
-       (desig:a motion (type moving-torso) (joint-angle ?angle))))))
-
-(defun move-bottle (m)
-  (btr-utils:move-object 'bottle-1
-                         (cl-tf:make-pose
-                          (cl-tf:v+ (cl-tf:origin (btr:object-pose 'bottle-1)) (cl-tf:make-3d-vector 0 m 0))
-                          (cl-tf:orientation (btr:object-pose 'bottle-1)))))
-
-(defun place-bottle ()
-  (proj:with-projection-environment pr2-proj::pr2-bullet-projection-environment
-    (cpl:top-level
-      (let ((?bottle (get-perceived-bottle-desig)))
-        (exe:perform (desig:an action
-                               (type placing)
-                               (object ?bottle)
-                               (arm right)))))))
-
-(defun test ()
-  )


### PR DESCRIPTION
Changes the call-ik-solver into a recursive function which recurses until all torso angles in the range from the upper to the lower limit (in steps of 0.01m) have been tried and no call returned a IK solution.
It also prevents the service call from printing a error message by temporarily increasing the debug level.
Otherwise for every failed call a pretty long error message would clutter the REPL.