### PR TITLE
Replace method get-object-type-grasp with prolog predicate object-type-grasp

### DIFF
--- a/cram_3d_world/cram_bullet_reasoning/cram-bullet-reasoning.asd
+++ b/cram_3d_world/cram_bullet_reasoning/cram-bullet-reasoning.asd
@@ -49,6 +49,7 @@
                  cram-designators
                  roslisp-utilities
                  cram-semantic-map-utils
+                 cram-object-interfaces
                  cram-robot-interfaces
                  cram-utilities ; lazy in pose-generators
                  cram-tf

--- a/cram_3d_world/cram_bullet_reasoning/package.xml
+++ b/cram_3d_world/cram_bullet_reasoning/package.xml
@@ -28,6 +28,7 @@
   <depend>cram_designators</depend>
   <depend>roslisp_utilities</depend>
   <depend>cram_semantic_map_utils</depend>
+  <depend>cram_object_interfaces</depend>
   <depend>cram_robot_interfaces</depend>
   <depend>cram_utilities</depend>
   <depend>cram_tf</depend>

--- a/cram_3d_world/cram_bullet_reasoning/src/reachability-facts.lisp
+++ b/cram_3d_world/cram_bullet_reasoning/src/reachability-facts.lisp
@@ -38,7 +38,10 @@
   ;; reachability succeed.
   (<- (object-grasp ?world ?object ?grasp ?sides)
     (item-type ?world ?object ?object-type)
-    (object-type-grasp ?object-type ?grasp ?sides))
+    (cram-object-interfaces:object-type-grasp ?object-type ?grasp ?sides)
+    (cram-robot-interfaces:robot ?robot)
+    (cram-robot-interfaces:arm ?robot ?side)
+    (== ?sides (?side)))
 
   (<- (valid-grasp ?world ?object ?grasp ?sides)
     (-> (not (object-grasp ?world ?object ?_ ?_))

--- a/cram_boxy/cram_boxy_plans/src/composite-plan-designators.lisp
+++ b/cram_boxy/cram_boxy_plans/src/composite-plan-designators.lisp
@@ -83,7 +83,7 @@
     (property ?current-object-desig (:name ?object-name))
     (property ?action-designator (:arm ?arm))
     ;; infer missing information like ?grasp type, gripping ?effort, manipulation poses
-    (lisp-fun kr-assembly::get-object-type-grasp ?object-type ?grasp)
+    (obj-int:object-type-grasp ?object-type ?grasp)
     (lisp-fun kr-assembly::get-object-type-gripping-effort ?object-type ?effort)
     (lisp-fun kr-assembly::get-object-type-gripper-opening ?object-type ?gripper-opening)
     (lisp-fun cram-object-interfaces:get-object-transform ?current-object-desig ?object-transform)
@@ -114,7 +114,7 @@
     (lisp-fun cram-object-interfaces:get-object-transform ?current-on-object-designator
               ?on-object-transform)
     ;; infer missing information
-    (lisp-fun kr-assembly::get-object-type-grasp ?object-type ?grasp)
+    (obj-int:object-type-grasp ?object-type ?grasp)
     (lisp-fun kr-assembly::get-object-placing-poses ?on-object-name ?on-object-type
               ?object-name ?object-type :left ?grasp
               ?on-object-transform ?left-poses)
@@ -147,7 +147,7 @@
     (lisp-fun cram-object-interfaces:get-object-transform ?current-with-object-designator
               ?with-object-transform)
     ;; infer missing information
-    (lisp-fun kr-assembly::get-object-type-grasp ?object-type ?grasp)
+    (obj-int:object-type-grasp ?object-type ?grasp)
     (lisp-fun kr-assembly::get-object-placing-poses ?with-object-name ?with-object-type
               ?object-name ?object-type :left ?grasp
               ?with-object-transform ?left-poses)

--- a/cram_common/cram_mobile_pick_place_plans/src/pick-place-designators.lisp
+++ b/cram_common/cram_mobile_pick_place_plans/src/pick-place-designators.lisp
@@ -73,7 +73,7 @@
     (spec:property ?current-object-desig (:name ?object-name))
     (spec:property ?action-designator (:arm ?arm))
     ;; infer missing information like ?grasp type, gripping ?maximum-effort, manipulation poses
-    (lisp-fun obj-int:get-object-type-grasp ?object-type ?grasp)
+    (obj-int:object-type-grasp ?object-type ?grasp)
     (lisp-fun obj-int:get-object-type-gripping-effort ?object-type ?effort)
     (lisp-fun obj-int:get-object-type-gripper-opening ?object-type ?gripper-opening)
     (lisp-fun cram-object-interfaces:get-object-transform ?current-object-desig ?object-transform)
@@ -98,7 +98,7 @@
     (spec:property ?current-object-designator (:type ?object-type))
     (spec:property ?current-object-designator (:name ?object-name))
     ;; infer missing information
-    (lisp-fun obj-int:get-object-type-grasp ?object-type ?grasp)
+    (obj-int:object-type-grasp ?object-type ?grasp)
     ;; take object-pose from action-designator target otherwise from object-designator pose
     (-> (spec:property ?action-designator (:target ?location))
         (and (desig:current-designator ?location ?current-location-designator)

--- a/cram_common/cram_object_interfaces/src/manipulation.lisp
+++ b/cram_common/cram_object_interfaces/src/manipulation.lisp
@@ -29,9 +29,6 @@
 
 (in-package :cram-object-interfaces)
 
-(defgeneric get-object-type-grasp (object-type)
-  (:documentation "Returns either of :top, :side, :front."))
-
 (defgeneric get-object-type-gripping-effort (object-type)
   (:documentation "Returns effort in Nm, e.g. 50."))
 

--- a/cram_common/cram_object_interfaces/src/manipulation.lisp
+++ b/cram_common/cram_object_interfaces/src/manipulation.lisp
@@ -105,7 +105,7 @@ Gripper is defined by a convention where Z is pointing towards the object."))
               (get-object-type-lift-pose object-type arm grasp grasp-pose))))))
 
 
-(def-fact-group object-knowledge (object-rotationally-symmetric orientation-matters)
+(def-fact-group object-knowledge (object-rotationally-symmetric orientation-matters object-type-grasp)
 
   (<- (object-rotationally-symmetric ?object-type)
     (fail))
@@ -115,4 +115,7 @@ Gripper is defined by a convention where Z is pointing towards the object."))
   ;; knives, forks, etc, the orientation is important while for plates
   ;; the orientation doesn't matter at all.
   (<- (orientation-matters ?object-type-symbol)
+    (fail))
+
+  (<- (object-type-grasp ?object-type ?grasp)
     (fail)))

--- a/cram_common/cram_object_interfaces/src/package.lisp
+++ b/cram_common/cram_object_interfaces/src/package.lisp
@@ -37,7 +37,6 @@
    #:get-object-transform
    #:get-object-pose
    ;; manipulation
-   #:get-object-type-grasp
    #:get-object-type-gripping-effort
    #:get-object-type-gripper-opening
    #:get-object-type-to-gripper-transform

--- a/cram_common/cram_object_interfaces/src/package.lisp
+++ b/cram_common/cram_object_interfaces/src/package.lisp
@@ -47,4 +47,5 @@
    #:get-object-type-2nd-lift-pose
    #:get-object-grasping-poses
    #:object-rotationally-symmetric
-   #:orientation-matters))
+   #:orientation-matters
+   #:object-type-grasp))

--- a/cram_common/cram_robot_interfaces/src/grasps.lisp
+++ b/cram_common/cram_robot_interfaces/src/grasps.lisp
@@ -28,6 +28,13 @@
 
 (in-package :cram-robot-interfaces)
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;; DEPRECATION WARNING ;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; PRETTY MUCH EVERYTHING IN HERE IS DERPECATED.   ;;;
+;;; USE THE cram_object_interfaces PACKAGE INSTEAD. ;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (defvar *grasps* nil
   "An alist that maps grasps to orientations in the robot's root
   link. For internal use only.")

--- a/cram_knowrob/cram_knowrob_assembly/src/grasping.lisp
+++ b/cram_knowrob/cram_knowrob_assembly/src/grasping.lisp
@@ -38,7 +38,7 @@
   (cut:with-vars-bound (?GRASP)
       (car
        (prolog:prolog
-        `(get-object-type-grasp ,object-type ?grasp)))
+        `(object-type-grasp ,object-type ?grasp)))
     ?GRASP))
 
 (defmethod get-object-type-grasp ((object-type (eql :porsche-body))) :top)

--- a/cram_knowrob/cram_knowrob_assembly/src/grasping.lisp
+++ b/cram_knowrob/cram_knowrob_assembly/src/grasping.lisp
@@ -33,9 +33,14 @@
 (defparameter *default-small-z-offset* 0.07 "in meters")
 
 
+;; TODO (cpo): Remove and refactor
 (defmethod get-object-type-grasp (object-type)
-  "Default grasp is :top."
-  :top)
+  (cut:with-vars-bound (?GRASP)
+      (car
+       (prolog:prolog
+        `(get-object-type-grasp ,object-type ?grasp)))
+    ?GRASP))
+
 (defmethod get-object-type-grasp ((object-type (eql :porsche-body))) :top)
 (defmethod get-object-type-grasp ((object-type (eql :camaro-body))) :top)
 (defmethod get-object-type-grasp ((object-type (eql :chassis))) :side)
@@ -183,3 +188,10 @@
         (1 0 0)
         (0 0 -1)))))
 )
+
+(def-fact-group asm-object-knowledge (object-type)
+  (<- object-type-grasp :porsche-body :top)
+  (<- object-type-grasp :camaro-body :top)
+  (<- object-type-grasp :chassis :side)
+  (<- object-type-grasp :axle :top)
+  (<- object-type-grasp :wheel :top))

--- a/cram_knowrob/cram_knowrob_assembly/src/grasping.lisp
+++ b/cram_knowrob/cram_knowrob_assembly/src/grasping.lisp
@@ -32,22 +32,6 @@
 (defparameter *default-z-offset* 0.2 "in meters")
 (defparameter *default-small-z-offset* 0.07 "in meters")
 
-
-;; TODO (cpo): Remove and refactor
-(defmethod get-object-type-grasp (object-type)
-  (cut:with-vars-bound (?GRASP)
-      (car
-       (prolog:prolog
-        `(object-type-grasp ,object-type ?grasp)))
-    ?GRASP))
-
-(defmethod get-object-type-grasp ((object-type (eql :porsche-body))) :top)
-(defmethod get-object-type-grasp ((object-type (eql :camaro-body))) :top)
-(defmethod get-object-type-grasp ((object-type (eql :chassis))) :side)
-(defmethod get-object-type-grasp ((object-type (eql :axle))) :top)
-(defmethod get-object-type-grasp ((object-type (eql :wheel))) :top)
-
-
 (defmethod get-object-type-gripping-effort (object-type)
     "Default value is 35 Nm."
     35)

--- a/cram_knowrob/cram_knowrob_pick_place/src/grasping.lisp
+++ b/cram_knowrob/cram_knowrob_pick_place/src/grasping.lisp
@@ -67,7 +67,7 @@
   (cut:with-vars-bound (?GRASP)
       (car
        (prolog:prolog
-        `(get-object-type-grasp ,object-type ?grasp)))
+        `(object-type-grasp ,object-type ?grasp)))
     ?GRASP))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cram_knowrob/cram_knowrob_pick_place/src/grasping.lisp
+++ b/cram_knowrob/cram_knowrob_pick_place/src/grasping.lisp
@@ -64,31 +64,11 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defmethod get-object-type-grasp (object-type)
-  "Default grasp is :top."
-  :top)
-(defmethod get-object-type-grasp ((object-type (eql :cutlery))) :top)
-(defmethod get-object-type-grasp ((object-type (eql :spoon))) :top)
-(defmethod get-object-type-grasp ((object-type (eql :fork))) :top)
-(defmethod get-object-type-grasp ((object-type (eql :knife))) :top)
-
-(defmethod get-object-type-grasp ((object-type (eql :plate))) :side)
-
-(defmethod get-object-type-grasp ((object-type (eql :bottle))) :front)
-(defmethod get-object-type-grasp ((object-type (eql :bottle))) :side)
-
-(defmethod get-object-type-grasp ((object-type (eql :cup))) :side)
-(defmethod get-object-type-grasp ((object-type (eql :cup))) :top)
-(defmethod get-object-type-grasp ((object-type (eql :cup))) :front)
-
-(defmethod get-object-type-grasp ((object-type (eql :milk))) :front)
-(defmethod get-object-type-grasp ((object-type (eql :milk))) :side)
-;; (defmethod get-object-type-grasp ((object-type (eql :milk))) :top)
-
-(defmethod get-object-type-grasp ((object-type (eql :cereal))) :front)
-(defmethod get-object-type-grasp ((object-type (eql :cereal))) :top)
-;; (defmethod get-object-type-grasp ((object-type (eql :cereal))) :back).
-
-(defmethod get-object-type-grasp ((object-type (eql :bowl))) :top)
+  (cut:with-vars-bound (?GRASP)
+      (car
+       (prolog:prolog
+        `(get-object-type-grasp ,object-type ?grasp)))
+    ?GRASP))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -561,10 +541,34 @@
   (cram-tf:translate-pose grasp-pose :z-offset *lift-z-offset*))
 
 
-(def-fact-group pnp-object-knowledge (object-rotationally-symmetric orientation-matters)
+(def-fact-group pnp-object-knowledge (object-rotationally-symmetric orientation-matters object-type-grasp)
 
   (<- (object-rotationally-symmetric ?object-type)
     (member ?object-type (:plate :bottle :drink :cup :bowl)))
 
   (<- (orientation-matters ?object-type)
-    (member ?object-type (:knife :fork :spoon :cutlery :spatula))))
+    (member ?object-type (:knife :fork :spoon :cutlery :spatula)))
+
+  (<- (object-type-grasp :cutlery :top))
+  (<- (object-type-grasp :spoon :top))
+  (<- (object-type-grasp :fork :top))
+  (<- (object-type-grasp :knife :top))
+  
+  (<- (object-type-grasp :plate :side))
+  
+  (<- (object-type-grasp :bottle :side))
+  (<- (object-type-grasp :bottle :front))
+
+  (<- (object-type-grasp :cup :front))
+  (<- (object-type-grasp :cup :top))
+  (<- (object-type-grasp :cup :side))
+  
+  (<- (object-type-grasp :milk :side))
+  (<- (object-type-grasp :milk :front))
+  ;; (<- (object-type-grasp :milk :top))
+
+  (<- (object-type-grasp :cereal :top))
+  (<- (object-type-grasp :cereal :front))
+  ;; (<- (object-type-grasp :cereal :back))
+
+  (<- (object-type-grasp :bowl :top)))

--- a/cram_knowrob/cram_knowrob_pick_place/src/grasping.lisp
+++ b/cram_knowrob/cram_knowrob_pick_place/src/grasping.lisp
@@ -61,15 +61,6 @@
 (defparameter *bowl-grasp-x-offset* 0.07 "in meters")
 (defparameter *bowl-grasp-z-offset* 0.01 "in meters")
 
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(defmethod get-object-type-grasp (object-type)
-  (cut:with-vars-bound (?GRASP)
-      (car
-       (prolog:prolog
-        `(object-type-grasp ,object-type ?grasp)))
-    ?GRASP))
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defmethod get-object-type-gripping-effort (object-type)

--- a/cram_pr2/cram_pr2_description/src/arm-kinematics.lisp
+++ b/cram_pr2/cram_pr2_description/src/arm-kinematics.lisp
@@ -196,7 +196,8 @@
                   "r_gripper_l_finger_tip_frame"
                   "r_gripper_palm_link"))))
 
-(def-fact-group pr2-arm-kinematics-facts (end-effector-link
+(def-fact-group pr2-arm-kinematics-facts (arm
+                                          end-effector-link
                                           robot-tool-frame
                                           gripper-link gripper-joint
                                           planning-group
@@ -210,6 +211,9 @@
                                           arm-links arm-base-links
                                           hand-links
                                           standard-to-particular-gripper-transform)
+
+  (<- (arm pr2 :right))
+  (<- (arm pr2 :left))
 
   (<- (end-effector-link pr2 :left "l_wrist_roll_link"))
   (<- (end-effector-link pr2 :right "r_wrist_roll_link"))


### PR DESCRIPTION
Removes get-object-type-grasp generic and methods.
Adds arm predicate to cram_robot_interfaces.
Adds object-type-grasp predicate to cram_object_interfaces and refactors for it instead of the method.
Adds deprection comment to grasps.lisp in cram_robot_interfaces.