### PR TITLE
[pr2-projection] Fix torso angle resampling in ik solver call.

### DIFF
--- a/cram_pr2/cram_pr2_projection/src/ik.lisp
+++ b/cram_pr2/cram_pr2_projection/src/ik.lisp
@@ -226,7 +226,7 @@
       (unwind-protect
            (progn
              (roslisp:set-debug-level NIL 9)
-             (_call-ik-service-with-torso-resampling left-or-right cartesian-pose :seed-state seed-state
+             (call-ik-service-with-torso-resampling-inner left-or-right cartesian-pose :seed-state seed-state
                                                                                   :test-angle test-angle
                                                                                   :torso-angle torso-angle
                                                                                   :torso-lower-limit torso-lower-limit

--- a/cram_pr2/cram_pr2_projection/src/ik.lisp
+++ b/cram_pr2/cram_pr2_projection/src/ik.lisp
@@ -200,8 +200,8 @@
 
 (defun call-ik-service-with-torso-resampling (left-or-right cartesian-pose
                                               &key seed-state test-angle torso-angle torso-lower-limit torso-upper-limit)
-  (labels ((_call-ik-service-with-torso-resampling (left-or-right cartesian-pose
-                                                    &key seed-state test-angle torso-angle torso-lower-limit torso-upper-limit)
+  (labels ((call-ik-service-with-torso-resampling-inner (left-or-right cartesian-pose
+                                                         &key seed-state test-angle torso-angle torso-lower-limit torso-upper-limit)
              (let ((ik-solution (call-ik-service left-or-right cartesian-pose seed-state)))
                (if (not ik-solution)
                    (when (or (not test-angle) (> test-angle torso-lower-limit))
@@ -215,12 +215,12 @@
                             (next-torso-offset (- next-test-angle torso-angle))
                             (pseudo-pose (cram-tf:translate-pose cartesian-pose
                                                                  :z-offset (- torso-offset next-torso-offset))))
-                       (_call-ik-service-with-torso-resampling left-or-right pseudo-pose
-                                                               :seed-state seed-state
-                                                               :test-angle next-test-angle
-                                                               :torso-angle torso-angle
-                                                               :torso-lower-limit torso-lower-limit
-                                                               :torso-upper-limit torso-upper-limit)))
+                       (call-ik-service-with-torso-resampling-inner left-or-right pseudo-pose
+                                                                    :seed-state seed-state
+                                                                    :test-angle next-test-angle
+                                                                    :torso-angle torso-angle
+                                                                    :torso-lower-limit torso-lower-limit
+                                                                    :torso-upper-limit torso-upper-limit)))
                    (values ik-solution test-angle)))))
     (let ((old-debug-lvl (roslisp:debug-level NIL)))
       (unwind-protect

--- a/cram_pr2/cram_pr2_projection/src/ik.lisp
+++ b/cram_pr2/cram_pr2_projection/src/ik.lisp
@@ -123,7 +123,6 @@
 ;;      effort zero-vector)))
 ;; TODO: use bullet instead
 
-
 (defun call-ik-persistent-service (left-or-right cartesian-pose
                                    &optional (ik-base-frame "torso_lift_link"))
   (declare (type keyword left-or-right)
@@ -154,82 +153,85 @@
                        'moveit_msgs-msg:moveiterrorcodes
                        error-code)))))))
 
-(defparameter *torso-step* 0.01)
-
-(defun call-ik-service (left-or-right cartesian-pose
-                        &key seed-state test-angle torso-angle torso-lower-limit torso-upper-limit)
+(defun call-ik-service (left-or-right cartesian-pose &optional seed-state)
   (declare (type keyword left-or-right)
            (type cl-transforms-stamped:pose-stamped cartesian-pose))
-  (let ((ik-link (get-ik-solver-link left-or-right))
-        (old-debug-lvl (roslisp:debug-level NIL)))
-    (unwind-protect
-         (progn
-           (roslisp:set-debug-level NIL 9)
-           (handler-case
-               (roslisp:with-fields ((response-error-code (val error_code))
-                                     (joint-state (joint_state solution)))
-                   (progn
-                     (roslisp:wait-for-service (concatenate 'string
-                                                            (getf *ik-service-namespaces* left-or-right)
-                                                            "/get_ik_solver_info") 10.0)
-                     (roslisp:call-service
-                      (concatenate 'string (getf *ik-service-namespaces* left-or-right) "/get_ik")
-                      "moveit_msgs/GetPositionIK"
-                      (roslisp:make-request
-                       "moveit_msgs/GetPositionIK"
-                       (:ik_link_name :ik_request) ik-link
-                       (:pose_stamped :ik_request) (cl-transforms-stamped:to-msg
-                                                    (cram-tf:ensure-pose-in-frame
-                                                     cartesian-pose
-                                                     cram-tf:*robot-torso-frame*
-                                                     :use-zero-time t))
-                       (:joint_state :robot_state :ik_request) (or seed-state
-                                                                   (make-zero-seed-state left-or-right))
-                       (:timeout :ik_request) 1.0)))
-                 (cond ((eql response-error-code
-                             (roslisp-msg-protocol:symbol-code
-                              'moveit_msgs-msg:moveiterrorcodes
-                              :success))
-                        (roslisp:set-debug-level NIL old-debug-lvl)
-                        (values joint-state test-angle))
-                       ((eql response-error-code
-                             (roslisp-msg-protocol:symbol-code
-                              'moveit_msgs-msg:moveiterrorcodes
-                              :no_ik_solution)) nil)
-                       (t (error 'simple-error
-                                 :format-control "IK service failed: ~a"
-                                 :format-arguments (list
-                                                    (roslisp-msg-protocol:code-symbol
-                                                     'moveit_msgs-msg:moveiterrorcodes
-                                                     response-error-code))))))
+  (let ((ik-link (get-ik-solver-link left-or-right)))
+    (handler-case
+        (roslisp:with-fields ((response-error-code (val error_code))
+                              (joint-state (joint_state solution)))
+            (progn
+              (roslisp:wait-for-service (concatenate 'string
+                                                     (getf *ik-service-namespaces* left-or-right)
+                                                     "/get_ik_solver_info") 10.0)
+              (roslisp:call-service
+               (concatenate 'string (getf *ik-service-namespaces* left-or-right) "/get_ik")
+               "moveit_msgs/GetPositionIK"
+               (roslisp:make-request
+                "moveit_msgs/GetPositionIK"
+                (:ik_link_name :ik_request) ik-link
+                (:pose_stamped :ik_request) (cl-transforms-stamped:to-msg
+                                             (cram-tf:ensure-pose-in-frame
+                                              cartesian-pose
+                                              cram-tf:*robot-torso-frame*
+                                              :use-zero-time T))
+                (:joint_state :robot_state :ik_request) (or seed-state
+                                                            (make-zero-seed-state left-or-right))
+                (:timeout :ik_request) 1.0)))
+          (cond ((eql response-error-code
+                      (roslisp-msg-protocol:symbol-code
+                       'moveit_msgs-msg:moveiterrorcodes
+                       :success)) joint-state)
+                ((eql response-error-code
+                      (roslisp-msg-protocol:symbol-code
+                       'moveit_msgs-msg:moveiterrorcodes
+                       :no_ik_solution)) nil)
+                (T (error 'simple-error
+                          :format-control "IK service failed: ~a"
+                          :format-arguments (list
+                                             (roslisp-msg-protocol:code-symbol
+                                              'moveit_msgs-msg:moveiterrorcodes
+                                              response-error-code))))))
+      (simple-error (e)
+        (declare (ignore e))
+        nil))))
 
-             ;; if an error happened, try with a different torso angle recursively
-             (simple-error (e)
-               (declare (ignore e))
-               (if (or (not test-angle) (> test-angle torso-lower-limit))
-                   (let* ((cur-torso-angle torso-angle)
-                          (next-test-angle (if test-angle
-                                               (max torso-lower-limit (- test-angle *torso-step*))
-                                               torso-upper-limit))
-                          (torso-offset (if test-angle
-                                            (- test-angle cur-torso-angle)
-                                            0))
-                          (next-torso-offset (- next-test-angle cur-torso-angle))
-                          (pseudo-pose
-                            (cram-tf:translate-pose cartesian-pose
-                                                    :z-offset (- torso-offset next-torso-offset))))
-                     (multiple-value-bind (ik-solution result-angle)
-                         (call-ik-service left-or-right pseudo-pose
-                                          :torso-angle torso-angle
-                                          :torso-lower-limit torso-lower-limit
-                                          :torso-upper-limit torso-upper-limit
-                                          :test-angle next-test-angle)
-                       (when ik-solution
-                         (values ik-solution result-angle))))
-                   (format t "IK service call freaked out. No IK solution found.~%")))))
-      (roslisp:set-debug-level NIL old-debug-lvl))))
+(defparameter *torso-step* 0.01)
 
-
+(defun call-ik-service-with-torso-resampling (left-or-right cartesian-pose
+                                              &key seed-state test-angle torso-angle torso-lower-limit torso-upper-limit)
+  (labels ((_call-ik-service-with-torso-resampling (left-or-right cartesian-pose
+                                                    &key seed-state test-angle torso-angle torso-lower-limit torso-upper-limit)
+             (let ((ik-solution (call-ik-service left-or-right cartesian-pose seed-state)))
+               (if (not ik-solution)
+                   (when (or (not test-angle) (> test-angle torso-lower-limit))
+                     ;; When we have no ik solution and have a valid torso angle to try, use it to resample.
+                     (let* ((next-test-angle (if test-angle
+                                                 (max torso-lower-limit (- test-angle *torso-step*))
+                                                 torso-upper-limit))
+                            (torso-offset (if test-angle
+                                              (- test-angle torso-angle)
+                                              0))
+                            (next-torso-offset (- next-test-angle torso-angle))
+                            (pseudo-pose (cram-tf:translate-pose cartesian-pose
+                                                                 :z-offset (- torso-offset next-torso-offset))))
+                       (_call-ik-service-with-torso-resampling left-or-right pseudo-pose
+                                                               :seed-state seed-state
+                                                               :test-angle next-test-angle
+                                                               :torso-angle torso-angle
+                                                               :torso-lower-limit torso-lower-limit
+                                                               :torso-upper-limit torso-upper-limit)))
+                   (values ik-solution test-angle)))))
+    (let ((old-debug-lvl (roslisp:debug-level NIL)))
+      (unwind-protect
+           (progn
+             (roslisp:set-debug-level NIL 9)
+             (_call-ik-service-with-torso-resampling left-or-right cartesian-pose :seed-state seed-state
+                                                                                  :test-angle test-angle
+                                                                                  :torso-angle torso-angle
+                                                                                  :torso-lower-limit torso-lower-limit
+                                                                                  :torso-upper-limit torso-upper-limit))
+        (roslisp:set-debug-level NIL old-debug-lvl)))))
 
 (defun call-fk-service (left-or-right link-names-vector
                         &optional (fk-base-frame "torso_lift_link"))
@@ -268,7 +270,6 @@
     (simple-error (e)
       (format t "~a~%FK service call freaked out. Hmmm...~%" e))))
 
-
 (defmethod cram-robot-interfaces:compute-iks (pose-stamped
                                               &key link-name arm robot-state seed-state
                                                 (pose-stamped-frame
@@ -294,6 +295,6 @@
          (solution
            (call-ik-service arm
                             ee-pose
-                            :seed-state seed-state)))
+                            seed-state)))
     (when solution
       (list solution))))

--- a/cram_pr2/cram_pr2_projection/src/low-level.lisp
+++ b/cram_pr2/cram_pr2_projection/src/low-level.lisp
@@ -355,11 +355,11 @@
                              (cram-robot-interfaces:joint-upper-limit ?robot ?torso-joint ?upper-limit)
                              (btr:bullet-world ?world)
                              (btr:joint-state ?world ?robot ?torso-joint ?torso-angle))))
-                   (call-ik-service arm ee-pose :torso-angle ?torso-angle
-                                                :torso-lower-limit ?lower-limit
-                                                :torso-upper-limit ?upper-limit
-                                                ;; seed-state ; is todo
-                                                ))
+                   (call-ik-service-with-torso-resampling arm ee-pose :torso-angle ?torso-angle
+                                                                      :torso-lower-limit ?lower-limit
+                                                                      :torso-upper-limit ?upper-limit
+                                                                      ;; seed-state ; is todo
+                                                                      ))
                (unless ik-solution-msg
                  (cpl:fail 'common-fail:manipulation-pose-unreachable
                            :description (format nil "~a is unreachable for EE." ee-pose)))


### PR DESCRIPTION
Fixes the torso angle resampling in the low level ik-solver-call.
Now it resamples in all cases where there's no ik solution.
It also turns call-ik-service back into the pure ROS call it once was.