### PR TITLE
[pr2-proj] Add virtual links in the PR2 URDF to the projection tf tree.

### DIFF
--- a/cram_pr2/cram_pr2_projection/src/tf.lisp
+++ b/cram_pr2/cram_pr2_projection/src/tf.lisp
@@ -86,16 +86,17 @@
              (urdf-link-names (remove-if (lambda (x) (member x bullet-links))
                                          (loop for name being the hash-keys in urdf-links
                                                collecting name))))
-        (let ((prev-link-count))
+        (let ((prev-link-count 0))
           ;; while there are still links left to be asserted in tf
           (loop while (> (length urdf-link-names) 0)
                 do ;; if no links were asserted last loop, we are stuck and have to return
-                   (if (eq prev-link-count (length urdf-link-names))
+                   (if (= prev-link-count (length urdf-link-names))
                        (progn
-                           (roslisp:ros-error (pr2-proj tf) "Somehow a virtual link with no parents in the bullet world was found in the urdf. This should never happen.")
+                           (roslisp:ros-error (pr2-proj tf) "Somehow a virtual link with no parents in ~
+						   the bullet world was found in the urdf. This should never happen.")
                            (return))
                        (setf prev-link-count (length urdf-link-names)))
-                   (let ((next-round (list)))
+                   (let (next-round)
                      ;; try to assert a transform from a parent in the bullet world to the virtual links
                      (loop for link-name in urdf-link-names
                            do (let* ((link-joint (cl-urdf:from-joint (gethash link-name urdf-links)))
@@ -103,7 +104,8 @@
                                 (when (and (not (eq (cl-urdf:joint-type link-joint) :FIXED))
                                            display-warnings)
                                   (roslisp:ros-warn (pr2-proj tf)
-                                                    "Joint of ~a is ~a. Only links on FIXED joints should be asserted as virtual links."
+                                                    "Joint of ~a is ~a. Only links on FIXED joints should ~
+													be asserted as virtual links."
                                                     (cl-urdf:name link-joint)
                                                     (cl-urdf:joint-type link-joint)))
                                 (if (member parent-name bullet-links)

--- a/cram_pr2/cram_pr2_projection/src/tf.lisp
+++ b/cram_pr2/cram_pr2_projection/src/tf.lisp
@@ -93,7 +93,7 @@
                    (if (= prev-link-count (length urdf-link-names))
                        (progn
                            (roslisp:ros-error (pr2-proj tf) "Somehow a virtual link with no parents in ~
-						   the bullet world was found in the urdf. This should never happen.")
+                           the bullet world was found in the urdf. This should never happen.")
                            (return))
                        (setf prev-link-count (length urdf-link-names)))
                    (let (next-round)
@@ -105,7 +105,7 @@
                                            display-warnings)
                                   (roslisp:ros-warn (pr2-proj tf)
                                                     "Joint of ~a is ~a. Only links on FIXED joints should ~
-													be asserted as virtual links."
+                                                    be asserted as virtual links."
                                                     (cl-urdf:name link-joint)
                                                     (cl-urdf:joint-type link-joint)))
                                 (if (member parent-name bullet-links)

--- a/cram_pr2/cram_pr2_projection/src/tf.lisp
+++ b/cram_pr2/cram_pr2_projection/src/tf.lisp
@@ -32,7 +32,8 @@
                              (fixed-frame cram-tf:*fixed-frame*)
                              (odom-frame cram-tf:*odom-frame*)
                              (base-frame cram-tf:*robot-base-frame*)
-                             (time (cut:current-timestamp)))
+                             (time (cut:current-timestamp))
+                             (display-warnings nil))
   "Sets the transform from fixed frame to odom and then robot and all robot link transforms"
   ;; get the robot bullet object instance
   (cut:with-vars-bound (?robot-instance)
@@ -43,43 +44,81 @@
     (assert (not (cut:is-var ?robot-instance)))
 
     (let* ((robot-pose-in-map (btr:link-pose ?robot-instance base-frame))
-         (reference-transform-inv (cl-transforms:transform-inv
-                                   (cl-transforms:reference-transform robot-pose-in-map))))
+           (reference-transform-inv (cl-transforms:transform-inv
+                                     (cl-transforms:reference-transform robot-pose-in-map))))
 
-    ;; tell the tf transformer that the global fixed frame and the odom frame are the same
-    (cl-tf:set-transform
-     transformer
-     (cl-tf:make-transform-stamped
-      fixed-frame odom-frame time
-      (cl-transforms:make-identity-vector)
-      (cl-transforms:make-identity-rotation))
-     :suppress-callbacks t)
+      ;; tell the tf transformer that the global fixed frame and the odom frame are the same
+      (cl-tf:set-transform
+       transformer
+       (cl-tf:make-transform-stamped
+        fixed-frame odom-frame time
+        (cl-transforms:make-identity-vector)
+        (cl-transforms:make-identity-rotation))
+       :suppress-callbacks t)
 
-    ;; tell the tf transformer where the robot is in the odometry frame
-    (cl-tf:set-transform
-     transformer
-     (cl-tf:transform->transform-stamped
-      odom-frame base-frame time
-      (cl-transforms:pose->transform robot-pose-in-map))
-     :suppress-callbacks t)
+      ;; tell the tf transformer where the robot is in the odometry frame
+      (cl-tf:set-transform
+       transformer
+       (cl-tf:transform->transform-stamped
+        odom-frame base-frame time
+        (cl-transforms:pose->transform robot-pose-in-map))
+       :suppress-callbacks t)
 
-    ;; tell the tf transformer the current configuration of robot's joints
-    (dolist (link (btr:link-names ?robot-instance))
-      (unless (equal link base-frame)
-        (let ((transform (cl-transforms:transform*
-                          reference-transform-inv
-                          (cl-transforms:reference-transform
-                           (btr:link-pose ?robot-instance link)))))
-          (cl-tf:set-transform
-           transformer
-           (cl-tf:make-transform-stamped
-            base-frame link time
-            (cl-transforms:translation transform)
-            (cl-transforms:rotation transform))
-           :suppress-callbacks t))))
+      ;; tell the tf transformer the current configuration of robot's joints
+      (dolist (link (btr:link-names ?robot-instance))
+        (unless (equal link base-frame)
+          (let ((transform (cl-transforms:transform*
+                            reference-transform-inv
+                            (cl-transforms:reference-transform
+                             (btr:link-pose ?robot-instance link)))))
+            (cl-tf:set-transform
+             transformer
+             (cl-tf:make-transform-stamped
+              base-frame link time
+              (cl-transforms:translation transform)
+              (cl-transforms:rotation transform))
+             :suppress-callbacks t))))
 
-    ;; execute the TF update callbacks
-    (cl-tf:execute-changed-callbacks transformer))))
+      ;; tell the tf transformer about the virtual fixed joints
+      (let* ((bullet-links (btr:link-names ?robot-instance))
+             (urdf-links (cl-urdf:links (btr:urdf ?robot-instance)))
+             ;; get the names of the links, which are only present in the urdf
+             (urdf-link-names (remove-if (lambda (x) (member x bullet-links))
+                                         (loop for name being the hash-keys in urdf-links
+                                               collecting name))))
+        (let ((prev-link-count))
+          ;; while there are still links left to be asserted in tf
+          (loop while (> (length urdf-link-names) 0)
+                do ;; if no links were asserted last loop, we are stuck and have to return
+                   (if (eq prev-link-count (length urdf-link-names))
+                       (progn
+                           (roslisp:ros-error (pr2-proj tf) "Somehow a virtual link with no parents in the bullet world was found in the urdf. This should never happen.")
+                           (return))
+                       (setf prev-link-count (length urdf-link-names)))
+                   (let ((next-round (list)))
+                     ;; try to assert a transform from a parent in the bullet world to the virtual links
+                     (loop for link-name in urdf-link-names
+                           do (let* ((link-joint (cl-urdf:from-joint (gethash link-name urdf-links)))
+                                     (parent-name (cl-urdf:name (cl-urdf:parent link-joint))))
+                                (when (and (not (eq (cl-urdf:joint-type link-joint) :FIXED))
+                                           display-warnings)
+                                  (roslisp:ros-warn (pr2-proj tf)
+                                                    "Joint of ~a is ~a. Only links on FIXED joints should be asserted as virtual links."
+                                                    (cl-urdf:name link-joint)
+                                                    (cl-urdf:joint-type link-joint)))
+                                (if (member parent-name bullet-links)
+                                    (progn
+                                      (cl-tf:set-transform
+                                       cram-tf:*transformer*
+                                       (cl-tf:transform->transform-stamped parent-name link-name 0 (cl-urdf:origin link-joint))
+                                       :suppress-callbacks t)
+                                      (push link-name bullet-links))
+                                    (push link-name next-round))))
+                     (setf urdf-link-names next-round)
+                     (setf next-round (list))))))
+
+      ;; execute the TF update callbacks
+      (cl-tf:execute-changed-callbacks transformer))))
 
 (defmethod cram-occasions-events:on-event
     update-tf ((event cram-plan-occasions-events:robot-state-changed))


### PR DESCRIPTION
Basically iterate over the difference in links of the URDF and in the bullet world until they are the same.
Achieve this by setting transforms from the virtual link's parents to them and adding them to the bullet world list of links. Repeat until every virtual link is asserted into the projection tf. This works because those virtual links who have other virtual links as parents will be asserted on the next loop iteration.

If there are virtual links who don't exist in the hierarchy of the projection's tf the loop returns to not run into an endless loop. But even then every other virtual link will be asserted.