### PR TITLE
Add another key to reference a location

### DIFF
--- a/cram_common/cram_designator_specification/src/specs.lisp
+++ b/cram_common/cram_designator_specification/src/specs.lisp
@@ -97,7 +97,7 @@
 
   (<- (property ?designator (?location-key ?location))
     (lisp-pred typep ?designator desig:action-designator)
-    (member ?location-key (:target :location))
+    (member ?location-key (:target :location :located-at))
     (property-member (?location-key ?location) ?designator)
     (assert-type ?location desig:location-designator "ACTION SPEC:PROPERTY"))
 


### PR DESCRIPTION
If two keys for location designators are not enough, this adds the :located-at key. I used it for more complex and less compact action designators. 