### PR TITLE
Add variable for visibility threshold

### DIFF
--- a/cram_3d_world/cram_bullet_reasoning/src/package.lisp
+++ b/cram_3d_world/cram_bullet_reasoning/src/package.lisp
@@ -38,7 +38,7 @@
   (:import-from #:desig designator-groundings)
   (:shadowing-import-from #:cl-bullet points pose)
   (:shadow copy-object)
-  (:export *current-bullet-world* *current-timeline*
+  (:export *current-bullet-world* *current-timeline* *visibility-threshold* 
            merge-bounding-boxes aabb with-stored-world *debug-window*
            add-debug-window add-costmap-function-object
            add-costmap-sample-object clear-costmap-vis-object

--- a/cram_3d_world/cram_bullet_reasoning/src/visibility-reasoning.lisp
+++ b/cram_3d_world/cram_bullet_reasoning/src/visibility-reasoning.lisp
@@ -31,6 +31,7 @@
 (in-package :btr)
 
 (defvar *rendering-context* nil)
+(defvar *visibility-threshold* 0.9)
 
 (defstruct object-visibility
   percentage
@@ -177,13 +178,13 @@
                                                       T))))
                                        object-proxies))))))))))))
 
-(defun object-visible-p (world camera-pose object &optional(threshold 0.9))
+(defun object-visible-p (world camera-pose object &optional(threshold *visibility-threshold*))
   "Returns T if at least `threshold' of the object is visible"
   (let ((visibility (calculate-object-visibility world camera-pose object)))
     (>= (object-visibility-percentage visibility)
         threshold)))
 
-(defun occluding-objects (world camera-pose object &optional (threshold 0.9))
+(defun occluding-objects (world camera-pose object &optional (threshold *visibility-threshold*))
   "Returns the list of occluding objects if less than `threshold' of `object' is visible"
   (let ((visibility (calculate-object-visibility world camera-pose object)))
     (when (< (object-visibility-percentage visibility) threshold)


### PR DESCRIPTION
Object detection required 90% of the object to be visible, or else it is not detected. When stacking objects, the bottommost may get occluded easily. This implementation lets the programmer tweak the allowed level of occlusion.