### PR TITLE
Add ?retract-arms to fetch and deliver plans to prevent park-arms

### DIFF
--- a/cram_common/cram_designator_specification/src/specs.lisp
+++ b/cram_common/cram_designator_specification/src/specs.lisp
@@ -128,7 +128,13 @@
   (<- (property ?designator (:for ?for-value))
     (lisp-pred typep ?designator desig:action-designator)
     (property-member (:for ?for-value) ?designator)
-    (assert-type ?for-value (or keyword desig:object-designator) "ACTION SPEC:PROPERTY")))
+    (assert-type ?for-value (or keyword desig:object-designator) "ACTION SPEC:PROPERTY"))
+
+  (<- (property ?designator (?retract-arms-key ?retract-arms))
+    (lisp-pred typep ?designator desig:action-designator)
+    (member ?retract-arms-key (:retract :retract-arms))
+    (property-member (?retract-arms-key ?retract-arms) ?designator)
+    (assert-type ?retract-arms boolean "ACTION SPEC:PROPERTY")))
 
 
 (def-fact-group location-designator-specs (property)

--- a/cram_pr2/cram_pr2_fetch_deliver_plans/src/fetch-and-deliver-designators.lisp
+++ b/cram_pr2/cram_pr2_fetch_deliver_plans/src/fetch-and-deliver-designators.lisp
@@ -31,10 +31,13 @@
 
 (def-fact-group fetch-and-deliver-designators (desig:action-grounding)
 
-  (<- (desig:action-grounding ?action-designator (go-without-collisions ?location-designator))
+  (<- (desig:action-grounding ?action-designator (go-without-collisions
+                                                  ?location-designator ?retract-arms))
     (spec:property ?action-designator (:type :navigating))
     (spec:property ?action-designator (:location ?some-location-designator))
-    (desig:current-designator ?some-location-designator ?location-designator))
+    (desig:current-designator ?some-location-designator ?location-designator)
+    (or (spec:property ?action-designator (:retract-arms ?retract-arms))
+        (equal ?retract-arms T)))
 
   (<- (desig:action-grounding ?action-designator (search-for-object
                                                   ?object-designator ?location-designator))
@@ -46,7 +49,8 @@
 
   (<- (desig:action-grounding ?action-designator (fetch ?object-designator ?arm
                                                         ?location-designator
-                                                        ?pick-up-action-designator))
+                                                        ?pick-up-action-designator
+                                                        ?retract-arms))
     (spec:property ?action-designator (:type :fetching))
     (spec:property ?action-designator (:object ?some-object-designator))
     (desig:current-designator ?some-object-designator ?object-designator)
@@ -57,11 +61,14 @@
      ?action-designator (:pick-up-action ?some-pick-up-action-designator))
     (desig:current-designator ?some-pick-up-action-designator ?pick-up-action-designator)
     (or (spec:property ?action-designator (:arm ?arm))
-        (equal ?arm NIL)))
+        (equal ?arm NIL))
+    (or (spec:property ?action-designator (:retract-arms ?retract-arms))
+        (equal ?retract-arms T)))
 
   (<- (desig:action-grounding ?action-designator (deliver ?object-designator ?location-designator
                                                           ?robot-location-designator
-                                                          ?place-action-designator))
+                                                          ?place-action-designator
+                                                          ?retract-arms))
     (spec:property ?action-designator (:type :delivering))
     (spec:property ?action-designator (:object ?some-object-designator))
     (desig:current-designator ?some-object-designator ?object-designator)
@@ -72,13 +79,16 @@
     (desig:current-designator ?some-robot-location-designator ?robot-location-designator)
     (desig:desig-prop ;; spec:property
      ?action-designator (:place-action ?some-place-action-designator))
-    (desig:current-designator ?some-place-action-designator ?place-action-designator))
+    (desig:current-designator ?some-place-action-designator ?place-action-designator)
+    (or (spec:property ?action-designator (:retract-arms ?retract-arms))
+        (equal ?retract-arms T)))
 
   (<- (desig:action-grounding ?action-designator (transport
                                                   ?object-designator
                                                   ?fetching-location-designator
                                                   ?delivering-location-designator
-                                                  ?arm))
+                                                  ?arm
+                                                  ?retract-arms))
     (spec:property ?action-designator (:type :transporting))
     (spec:property ?action-designator (:object ?some-object-designator))
     (desig:current-designator ?some-object-designator ?object-designator)
@@ -87,4 +97,6 @@
     (spec:property ?action-designator (:target ?some-delivering-location-designator))
     (desig:current-designator ?some-delivering-location-designator ?delivering-location-designator)
     (or (spec:property ?action-designator (:arm ?arm))
-        (equal ?arm NIL))))
+        (equal ?arm NIL))
+    (or (spec:property ?action-designator (:retract-arms ?retract-arms))
+        (equal ?retract-arms T))))


### PR DESCRIPTION
Sometimes the robot should not be allowed to retract his arms, when transporting an object (e.g. a loaded tray). Therefore setting ?retract-arms to NIL prevents performing park-arms, after lifting an object. This parameter is optional and T by default.