### PR TITLE
Environment Manipulation Fixes

### DIFF
--- a/cram_pr2/cram_pr2_environment_manipulation/cram-pr2-environment-manipulation.asd
+++ b/cram_pr2/cram_pr2_environment_manipulation/cram-pr2-environment-manipulation.asd
@@ -30,7 +30,9 @@
     :author "Christopher Pollok"
     :license "BSD"
 
-    :depends-on (cl-transforms
+    :depends-on (roslisp-utilities
+
+                 cl-transforms
                  cl-transforms-stamped
                  cl-tf
                  cram-tf

--- a/cram_pr2/cram_pr2_environment_manipulation/src/action-designators.lisp
+++ b/cram_pr2/cram_pr2_environment_manipulation/src/action-designators.lisp
@@ -29,6 +29,17 @@
 
 (in-package :pr2-em)
 
+(defun get-container-pose-and-transform (name)
+  (let* ((name-rosified (roslisp-utilities:rosify-underscores-lisp-name name))
+         (urdf-pose (get-urdf-link-pose name-rosified))
+         (pose (cl-tf:transform-pose-stamped cram-tf:*transformer*
+                                             :target-frame cram-tf:*robot-base-frame*
+                                             :pose (cl-tf:pose->pose-stamped cram-tf:*fixed-frame*
+                                                                             0
+                                                                             urdf-pose)))
+         (transform (cram-tf:pose-stamped->transform-stamped pose name-rosified)))
+    (list pose transform)))
+
 (def-fact-group environment-manipulation (desig:action-grounding)
   
   (<- (desig:action-grounding ?action-designator (open-container ?arm
@@ -59,7 +70,8 @@
     (lisp-fun btr:object ?world ?environment ?environment-obj)
     ;; infer missing information like ?gripper-opening, opening trajectory
     (lisp-fun obj-int:get-object-type-gripper-opening ?container-type ?gripper-opening)
-    (lisp-fun obj-int:get-object-transform ?container-designator ?container-transform)
+    (lisp-fun get-container-pose-and-transform ?container-name
+              (?container-pose ?container-transform))
     (lisp-fun obj-int:get-object-grasping-poses ?container-name
               :container :left :open ?container-transform ?left-poses)
     (lisp-fun obj-int:get-object-grasping-poses ?container-name
@@ -102,7 +114,8 @@
     (lisp-fun btr:object ?world ?environment ?environment-obj)
     ;; infer missing information like ?gripper-opnening, closing trajectory
     (lisp-fun obj-int:get-object-type-gripper-opening ?container-type ?gripper-opening)
-    (lisp-fun obj-int:get-object-transform ?container-designator ?container-transform)
+    (lisp-fun get-container-pose-and-transform ?container-name
+              (?container-pose ?container-transform))
     (lisp-fun obj-int:get-object-grasping-poses ?container-name
               :container :left :close ?container-transform ?left-poses)
     (lisp-fun obj-int:get-object-grasping-poses ?container-name

--- a/cram_pr2/cram_pr2_environment_manipulation/src/grasping.lisp
+++ b/cram_pr2/cram_pr2_environment_manipulation/src/grasping.lisp
@@ -31,13 +31,18 @@
 
 ;;; OBJECT-INTERFACE METHODS
 
-(defparameter *drawer-handle-grasp-x-offset* -0.02 "in meters")
+(defparameter *drawer-handle-grasp-x-offset* 0.0 "in meters")
 (defparameter *drawer-handle-pregrasp-x-offset* 0.10 "in meters")
-(defparameter *drawer-handle-lift-x-offset* 0.48 "in meters")
-(defparameter *drawer-handle-2nd-lift-x-offset* 0.58 "in meters")
-(defparameter *drawer-handle-2nd-lift-closing-x-offset* -0.38 "in meters")
+(defparameter *drawer-handle-lift-x-offset* 0.30 "in meters")
+(defparameter *drawer-handle-2nd-lift-x-offset* (+ *drawer-handle-lift-x-offset*
+                                                   *drawer-handle-pregrasp-x-offset*)
+  "in meters")
+(defparameter *drawer-handle-2nd-lift-closing-x-offset* (+ (- *drawer-handle-lift-x-offset*)
+                                                           *drawer-handle-pregrasp-x-offset*)
+  "in meters")
 
-;; Might be necessary to find out what kind of handle we are dealing with. But we could also just open wide and be done with it.
+;; Might be necessary to find out what kind of handle we are dealing with.
+;; But we could also just open wide and be done with it.
 (defmethod obj-int:get-object-type-gripper-opening ((object-type (eql :container)))
   0.09)
 
@@ -78,6 +83,13 @@
                                                                    arm
                                                                    grasp
                                                                    grasp-pose)
+  (cram-tf:translate-transform-stamped grasp-pose :x-offset *drawer-handle-pregrasp-x-offset*))
+
+(defmethod obj-int:get-object-type-to-gripper-2nd-pregrasp-transform ((object-type (eql :container))
+                                                                      object-name
+                                                                      arm
+                                                                      grasp
+                                                                      grasp-pose)
   (cram-tf:translate-transform-stamped grasp-pose :x-offset *drawer-handle-pregrasp-x-offset*))
 
 ;; We need the joint-type, maybe contain it in the object-type e.g. 'container-prismatic'.


### PR DESCRIPTION
Defines the 2nd-pregrasp-pose for containers and also includes the calculation of pose and transform of containers in the action designator reference. So the designators don't have to pre-calculate a pose, to be able to be referenced.