### PR TITLE
Environment Manipulation - Drawer costmap improvements

### DIFF
--- a/cram_pr2/cram_pr2_environment_manipulation/cram-pr2-environment-manipulation.asd
+++ b/cram_pr2/cram_pr2_environment_manipulation/cram-pr2-environment-manipulation.asd
@@ -54,7 +54,6 @@
                cram-bullet-reasoning-belief-state
                cram-bullet-reasoning-utilities
 
-               cram-semantic-map-costmap
                cram-robot-pose-gaussian-costmap
                cram-occupancy-grid-costmap
                cram-location-costmap)

--- a/cram_pr2/cram_pr2_environment_manipulation/package.xml
+++ b/cram_pr2/cram_pr2_environment_manipulation/package.xml
@@ -30,7 +30,6 @@
   <depend>cram_bullet_reasoning</depend>
   <depend>cram_bullet_reasoning_belief_state</depend>
   <depend>cram_bullet_reasoning_utilities</depend>
-  <depend>cram_semantic_map_costmap</depend>
   <depend>cram_robot_pose_gaussian_costmap</depend>
   <depend>cram_occupancy_grid_costmap</depend>
   <depend>cram_location_costmap</depend>

--- a/cram_pr2/cram_pr2_environment_manipulation/src/costmaps.lisp
+++ b/cram_pr2/cram_pr2_environment_manipulation/src/costmaps.lisp
@@ -99,6 +99,7 @@ in neutral and manipulated form."
                (dist-p (line-p-dist-point a b c P)))
           (if (and
                (< dist (+ (/ width 2) padding))
+               ;; Commenting this out for now, so there won't be poses in front of the drawer.
                ;;(< (cl-transforms:v-norm (cl-transforms:v- dist-p neutral-point))
                ;;   (+ (cl-transforms:v-norm V) padding))
                )
@@ -206,6 +207,7 @@ quaternions to face from `pos1' to `pos2'."
      (make-opened-drawer-side-cost-function ?container-designator ?arm)
      ?costmap)
     ;; orientation generator
+    ;; generate an orientation opposite to the axis of the drawer
     (equal ?poses (?pose1 ?pose2))
     (costmap:orientation-samples ?samples)
     (costmap:orientation-sample-step ?sample-step)


### PR DESCRIPTION
Removes costmap generation in front of drawers, so that the robot stands on the side of the drawer. The rotation is adjusted, so that the robot faces a direction opposite to the drawers axis.

Also in here: Removed a unnecessary dependency on cram-semantic-map-costmap.