### PR TITLE
[bullet] Restrict joint states to limits. Solves issue #54

### DIFF
--- a/cram_3d_world/cram_bullet_reasoning/src/robot-model.lisp
+++ b/cram_3d_world/cram_bullet_reasoning/src/robot-model.lisp
@@ -453,7 +453,7 @@ current joint states"
            (parent (cl-urdf:parent joint))
            (parent-pose (find-parent-pose obj name))
            (limits (cl-urdf:limits joint)))
-      (when limits
+      (when (and limits (not (eq (cl-urdf:lower limits) (cl-urdf:upper limits))))
         (setf new-value (min (max new-value (cl-urdf:lower limits))
                              (cl-urdf:upper limits))))
       (when joint

--- a/cram_3d_world/cram_bullet_reasoning/src/robot-model.lisp
+++ b/cram_3d_world/cram_bullet_reasoning/src/robot-model.lisp
@@ -451,7 +451,11 @@ current joint states"
     (let* ((joint-states (joint-states obj))
            (joint (gethash name (cl-urdf:joints urdf)))
            (parent (cl-urdf:parent joint))
-           (parent-pose (find-parent-pose obj name)))
+           (parent-pose (find-parent-pose obj name))
+           (limits (cl-urdf:limits joint)))
+      (when limits
+        (setf new-value (min (max new-value (cl-urdf:lower limits))
+                             (cl-urdf:upper limits))))
       (when joint
         (let ((joint-transform
                 (cl-transforms:transform*


### PR DESCRIPTION
#54 Solved. Requested value for a joint too high? -> take upper limit. Too low? -> take lower. Everything within is fine. Requires kitchen to be loaded as URDF (comes with cram7).