### PR TITLE
Fixed bullet attach items

### DIFF
--- a/cram_3d_world/cram_bullet_reasoning/src/items.lisp
+++ b/cram_3d_world/cram_bullet_reasoning/src/items.lisp
@@ -75,7 +75,10 @@ The name in the list is a keyword that is created by lispifying the filename."
                               (format nil "package://~a/~a/*.*" ros-package directory))))))
 
 (defclass item (object)
-  ((types :reader item-types :initarg :types)))
+  ((types :reader item-types :initarg :types)
+   (attached-items :type 'list
+                   :initform (list)
+                   :accessor attached-items)))
 
 (defmethod copy-object ((object item) (world bt-reasoning-world))
   (change-class (call-next-method) 'item
@@ -271,3 +274,43 @@ The name in the list is a keyword that is created by lispifying the filename."
                 :collision-shape (make-instance 'colored-box-shape
                                    :half-extents (ensure-vector size)
                                    :color color)))))
+(defgeneric attach-item (attachment-name attach-to)
+  (:documentation "Adds an attachment to the a-list of `attached-items'. The new
+  entry has the `attachment's name as car and the pose of the item `attach-to' as
+  cadr. Since we save the original `attach-to' pose at the time attaching, you are
+  able to calculate the transformation of the `attach-to' item, when its pose changes,
+  to change the pose of its attachments as well.")
+  (:method (attachment-name (attach-to item))
+    (unless (member attachment-name (attached-items attach-to)) 
+      (push attachment-name (attached-items attach-to))
+      (setf (mass (car (rigid-bodies (object *current-bullet-world* attachment-name)))) 0.0))))
+
+(defgeneric detach-item (attachment-name attached-to)
+  (:documentation "Removes the item of name `attachment-name' from the `attached-items'
+  list of the item `attached-to'.")
+  (:method (attachment-name (attached-to item))
+    (setf (attached-items attached-to) (remove attachment-name (attached-items attached-to)))
+    (setf (mass (car (rigid-bodies (object *current-bullet-world* attachment-name)))) 0.2)))
+
+(defgeneric detach-all-items (attached-to)
+  (:documentation "Removes all items from the list of `attached-items' of the item `attached-to'.")
+  (:method ((attached-to item))
+    (loop for attachment in (attached-items attached-to)
+          do (detach-item attachment attached-to))))
+
+(defmethod (setf pose) :around (new-value (object item))
+  "TODO: Maybe check for both-directional attachments to be sure..."
+  (if (and (slot-boundp object 'attached-items)
+           (< 0 (length (attached-items object))))
+      (let ((carrier-transform
+              (cl-transforms:transform-diff (cl-tf:pose->transform (cl-tf:copy-pose new-value))
+                                            (cl-tf:pose->transform (cl-tf:copy-pose (pose object))))))
+        (call-next-method)
+        (dolist (attachment (attached-items object))
+          (let ((current-attachment-pose (object-pose attachment)))
+            (when (and carrier-transform current-attachment-pose)
+              (setf (pose (btr:object btr:*current-bullet-world* attachment))
+                    (cl-transforms:transform-pose
+                     carrier-transform
+                     current-attachment-pose))))))
+      (call-next-method)))

--- a/cram_3d_world/cram_bullet_reasoning/src/robot-model-facts.lisp
+++ b/cram_3d_world/cram_bullet_reasoning/src/robot-model-facts.lisp
@@ -125,6 +125,17 @@
   (<- (assert (attached ?world ?robot ?link-name ?object))
     (assert ?world (attached ?robot ?link-name ?object)))
 
+  (<- (assert (retract ?world ?robot-name ?object-name ?link-name))
+    ;; ?link-name is not mandatory
+    (bound ?robot-name)
+    (bound ?object-name)
+    (bullet-world ?world)
+    (attached ?world ?robot-name ?link-name ?object-name)
+    (%object ?world ?robot-name ?robot)
+    (%object ?world ?object-name ?object)
+    (lisp-fun detach-object ?robot ?object ?link-name ?_)
+    (not (attached ?world ?robot-name ?link-name ?object-name)))
+  
   (<- (retract ?world (attached ?robot ?object))
     (bullet-world ?world)
     (%object ?world ?robot ?robot-instance)


### PR DESCRIPTION
Originally PR #49 but my fork master was out of sync. This PR contains only the relevant 2 commits.
From original PR:
Using a carrier to transport multiple objects requires this implementation. You can attach one item to another, to make it move when the carrier moves.
Additional:
Provides a more intuitive predicate to detach items from a robot. 
```
;; Attach fork-1 to sink drawer
(prolog '(and (btr:bullet-world ?world)
              (btr:%object ?world fork-1 ?fork)
              (assert (btr:attached ?world :kitchen "sink_area_left_upper_drawer_main" ?fork))))
;; Detach fork from any joint of the kitchen
(prolog '(and (btr:bullet-world ?world)
              (assert (btr:retract ?world :kitchen fork-1 ?_))))
```