### PR TITLE
Adding support to place objects inside Containers

### DIFF
--- a/cram_3d_world/cram_btr_spatial_relations_costmap/src/cost-functions.lisp
+++ b/cram_3d_world/cram_btr_spatial_relations_costmap/src/cost-functions.lisp
@@ -405,7 +405,7 @@ if it is on the sign side of the axis. "
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; HEIGHT GENERATORS ;;;;;;;;;;;;;;;;;;;;;;;
 
-(defparameter *board-thickness* 0.035)
+(defparameter *board-thickness* 0.040)
 
 (defun make-object-bounding-box-height-generator (object &optional (tag :on))
   (constantly (list

--- a/cram_3d_world/cram_btr_spatial_relations_costmap/src/cost-functions.lisp
+++ b/cram_3d_world/cram_btr_spatial_relations_costmap/src/cost-functions.lisp
@@ -403,6 +403,26 @@ if it is on the sign side of the axis. "
             1.0
             0.0)))))
 
+(defun make-object-in-object-bounding-box-costmap-generator (container-object inner-object)
+  (let* ((bounding-box-dims (btr:calculate-bb-dims container-object))
+         (container-dimensions-x/2 (/ (cl-transforms:x bounding-box-dims) 2))
+         (container-dimensions-y/2 (/ (cl-transforms:y bounding-box-dims) 2))
+         (center-x (cl-transforms:x (cl-transforms:origin (btr:pose container-object))))
+         (center-y (cl-transforms:y (cl-transforms:origin (btr:pose container-object))))
+         (inner-obj-bb (btr:calculate-bb-dims inner-object))
+         (inner-obj-x/2 (/ (cl-transforms:x inner-obj-bb) 2))
+         (inner-obj-y/2 (/ (cl-transforms:y inner-obj-bb) 2))
+         (inner-obj-padding (max inner-obj-x/2 inner-obj-y/2))
+         (dimensions-x/2 (- container-dimensions-x/2 inner-obj-padding))
+         (dimensions-y/2 (- container-dimensions-y/2 inner-obj-padding)))
+    (lambda (x y)
+      (if (and
+           (< x (+ center-x dimensions-x/2))
+           (> x (- center-x dimensions-x/2))
+           (< y (+ center-y dimensions-y/2))
+           (> y (- center-y dimensions-y/2)))
+          1.0 0.0))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; HEIGHT GENERATORS ;;;;;;;;;;;;;;;;;;;;;;;
 
 (defparameter *board-thickness* 0.040)

--- a/cram_3d_world/cram_btr_spatial_relations_costmap/src/cost-functions.lisp
+++ b/cram_3d_world/cram_btr_spatial_relations_costmap/src/cost-functions.lisp
@@ -422,14 +422,25 @@ if it is on the sign side of the axis. "
                                2.0))
                          *board-thickness*))))))
 
-(defun make-object-on-object-bb-height-generator (environment-objects for-object)
+(defun make-object-on-object-bb-height-generator (environment-objects for-object
+                                                  &optional (tag :on))
   (let* ((environment-object-top
            (apply #'max
                   (mapcar (lambda (environment-object)
-                            (+ (cl-transforms:z
-                                (cl-transforms:origin (btr:pose environment-object)))
-                               (/ (cl-transforms:z (btr:calculate-bb-dims environment-object))
-                                  2.0)))
+                            (ecase tag
+                              (:on (+ (cl-transforms:z
+                                       (cl-transforms:origin
+                                        (btr:pose environment-object)))
+                                      (/ (cl-transforms:z
+                                          (btr:calculate-bb-dims environment-object))
+                                         2.0)))
+                              (:in (+ (cl-transforms:z
+                                       (cl-transforms:origin
+                                        (btr:pose environment-object)))
+                                      (- (/ (cl-transforms:z
+                                             (btr:calculate-bb-dims environment-object))
+                                            2.0))
+                                      *board-thickness*))))
                           (if (listp environment-objects)
                               environment-objects
                               (list environment-objects)))))

--- a/cram_3d_world/cram_btr_spatial_relations_costmap/src/prolog.lisp
+++ b/cram_3d_world/cram_btr_spatial_relations_costmap/src/prolog.lisp
@@ -410,7 +410,7 @@
      (make-object-bounding-box-height-generator ?environment-link :in)
      ?costmap))
 
-    (<- (costmap:desig-costmap ?designator ?costmap)
+  (<- (costmap:desig-costmap ?designator ?costmap)
     (desig:desig-prop ?designator (:in ?object))
     (spec:property ?object (:type ?object-type))
     (man-int:object-type-subtype :container ?object-type)

--- a/cram_3d_world/cram_btr_spatial_relations_costmap/src/prolog.lisp
+++ b/cram_3d_world/cram_btr_spatial_relations_costmap/src/prolog.lisp
@@ -406,25 +406,6 @@
      on-bounding-box
      (make-object-bounding-box-costmap-generator ?environment-link)
      ?costmap)
-    (costmap:costmap-add-cached-height-generator
-     (make-object-bounding-box-height-generator ?environment-link :in)
-     ?costmap))
-
-  (<- (costmap:desig-costmap ?designator ?costmap)
-    (desig:desig-prop ?designator (:in ?object))
-    (spec:property ?object (:type ?object-type))
-    (man-int:object-type-subtype :container ?object-type)
-    (spec:property ?object (:urdf-name ?urdf-name))
-    (spec:property ?object (:part-of ?environment-name))
-    (btr:bullet-world ?world)
-    (btr:%object ?world ?environment-name ?environment)
-    (lisp-fun get-link-rigid-body ?environment ?urdf-name ?environment-link)
-    (lisp-pred identity ?environment-link)
-    (costmap:costmap ?costmap)
-    (costmap:costmap-add-function
-     on-bounding-box
-     (make-object-bounding-box-costmap-generator ?environment-link)
-     ?costmap)
     (once (or (desig:desig-prop ?designator (:for ?_))
               (costmap:costmap-add-cached-height-generator
                (make-object-bounding-box-height-generator ?environment-link :in)
@@ -446,6 +427,11 @@
     (lisp-pred identity ?environment-link)
     (btr-belief:object-designator-name ?for-object ?for-object-name)
     (btr:%object ?world ?for-object-name ?for-object-instance)
+    (costmap:costmap-add-function
+     on-bounding-box
+     (make-object-in-object-bounding-box-costmap-generator
+      ?environment-link ?for-object-instance)
+     ?costmap)
     (costmap:costmap-add-height-generator
      (make-object-on-object-bb-height-generator ?environment-link ?for-object-instance :in)
      ?costmap))

--- a/cram_3d_world/cram_btr_spatial_relations_costmap/src/prolog.lisp
+++ b/cram_3d_world/cram_btr_spatial_relations_costmap/src/prolog.lisp
@@ -373,7 +373,7 @@
      (make-discrete-orientations-generator)
      ?costmap))
 
-;; height generator for locations ((on something) (name something) (for some-obj))
+;; height generator for locations ((on something) (for some-obj))
   (<- (costmap:desig-costmap ?designator ?costmap)
     (desig:desig-prop ?designator (:for ?for-object))
     (desig:desig-prop ?designator (:on ?on-object))
@@ -387,7 +387,7 @@
     (btr-belief:object-designator-name ?for-object ?for-object-name)
     (btr:%object ?world ?for-object-name ?for-object-instance)
     (costmap:costmap-add-height-generator
-     (make-object-on-object-bb-height-generator ?environment-link ?for-object-instance)
+     (make-object-on-object-bb-height-generator ?environment-link ?for-object-instance :on)
      ?costmap))
 
 ;;;;;;;;;;;;;;; spatial relation IN for environment objects ;;;;;;;;;;;;;;;;;;;
@@ -408,6 +408,46 @@
      ?costmap)
     (costmap:costmap-add-cached-height-generator
      (make-object-bounding-box-height-generator ?environment-link :in)
+     ?costmap))
+
+    (<- (costmap:desig-costmap ?designator ?costmap)
+    (desig:desig-prop ?designator (:in ?object))
+    (spec:property ?object (:type ?object-type))
+    (man-int:object-type-subtype :container ?object-type)
+    (spec:property ?object (:urdf-name ?urdf-name))
+    (spec:property ?object (:part-of ?environment-name))
+    (btr:bullet-world ?world)
+    (btr:%object ?world ?environment-name ?environment)
+    (lisp-fun get-link-rigid-body ?environment ?urdf-name ?environment-link)
+    (lisp-pred identity ?environment-link)
+    (costmap:costmap ?costmap)
+    (costmap:costmap-add-function
+     on-bounding-box
+     (make-object-bounding-box-costmap-generator ?environment-link)
+     ?costmap)
+    (once (or (desig:desig-prop ?designator (:for ?_))
+              (costmap:costmap-add-cached-height-generator
+               (make-object-bounding-box-height-generator ?environment-link :in)
+               ?costmap)))
+    (costmap:costmap-add-orientation-generator
+     (make-discrete-orientations-generator)
+     ?costmap))
+
+;; height generator for locations ((in something) (for some-obj))
+  (<- (costmap:desig-costmap ?designator ?costmap)
+    (desig:desig-prop ?designator (:for ?for-object))
+    (desig:desig-prop ?designator (:in ?in-object))
+    (desig:desig-prop ?in-object (:urdf-name ?urdf-name))
+    (desig:desig-prop ?in-object (:part-of ?environment-name))
+    (costmap:costmap ?costmap)
+    (btr:bullet-world ?world)
+    (btr:%object ?world ?environment-name ?environment-object)
+    (lisp-fun get-link-rigid-body ?environment-object ?urdf-name ?environment-link)
+    (lisp-pred identity ?environment-link)
+    (btr-belief:object-designator-name ?for-object ?for-object-name)
+    (btr:%object ?world ?for-object-name ?for-object-instance)
+    (costmap:costmap-add-height-generator
+     (make-object-on-object-bb-height-generator ?environment-link ?for-object-instance :in)
      ?costmap))
 
 ;;;;;;;;;;;;;; for TABLE-SETTING context ON (SLOTS) ;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cram_3d_world/cram_bullet_reasoning_belief_state/src/event-handlers.lisp
+++ b/cram_3d_world/cram_bullet_reasoning_belief_state/src/event-handlers.lisp
@@ -71,7 +71,7 @@ If there is no other method with 1 as qualifier, this method will be executed al
     (when (cut:is-var link) (error "[BTR-BELIEF OBJECT-DETACHED] Couldn't find robot's EE link."))
     (when btr-object
       (btr:detach-object robot-object btr-object link)
-      (btr:simulate btr:*current-bullet-world* 100)
+      (btr:simulate btr:*current-bullet-world* 10)
       ;; finding the link that supports the object now
       (let ((environment-object (btr:get-environment-object))
             (environment-link (cut:var-value
@@ -80,9 +80,9 @@ If there is no other method with 1 as qualifier, this method will be executed al
                                   `(and (btr:bullet-world ?world)
                                         (btr:supported-by
                                          ?world ,btr-object-name ?env-name ?env-link)))))))
-        (when (cut:is-var environment-link)
-          (error "[BTR-BELIEF OBJECT-DETACHED] Couldn't find the link supporting ~a" btr-object-name))
-        (btr:attach-object environment-object btr-object environment-link)))))
+        ;; attaching the link to the object if it finds one.
+        (unless (cut:is-var environment-link)
+          (btr:attach-object environment-object btr-object environment-link))))))
 
 #+implement-this-when-object-to-object-is-implemented
 (defmethod cram-occasions-events:on-event btr-attach-two-objs ((event cpoe:object-attached-object))

--- a/cram_3d_world/cram_bullet_reasoning_belief_state/src/event-handlers.lisp
+++ b/cram_3d_world/cram_bullet_reasoning_belief_state/src/event-handlers.lisp
@@ -71,7 +71,18 @@ If there is no other method with 1 as qualifier, this method will be executed al
     (when (cut:is-var link) (error "[BTR-BELIEF OBJECT-DETACHED] Couldn't find robot's EE link."))
     (when btr-object
       (btr:detach-object robot-object btr-object link)
-      (btr:simulate btr:*current-bullet-world* 10))))
+      (btr:simulate btr:*current-bullet-world* 100)
+      ;; finding the link that supports the object now
+      (let ((environment-object (btr:get-environment-object))
+            (environment-link (cut:var-value
+                            '?env-link
+                            (car (prolog:prolog
+                                  `(and (btr:bullet-world ?world)
+                                        (btr:supported-by
+                                         ?world ,btr-object-name ?env-name ?env-link)))))))
+        (when (cut:is-var environment-link)
+          (error "[BTR-BELIEF OBJECT-DETACHED] Couldn't find the link supporting ~a" btr-object-name))
+        (btr:attach-object environment-object btr-object environment-link)))))
 
 #+implement-this-when-object-to-object-is-implemented
 (defmethod cram-occasions-events:on-event btr-attach-two-objs ((event cpoe:object-attached-object))

--- a/cram_pr2/cram_pr2_fetch_deliver_plans/src/fetch-and-deliver-designators.lisp
+++ b/cram_pr2/cram_pr2_fetch_deliver_plans/src/fetch-and-deliver-designators.lisp
@@ -257,6 +257,9 @@ the `look-pose-stamped'."
                    (:target ?some-delivering-location-designator))
     (desig:current-designator ?some-delivering-location-designator
                               ?delivering-location-designator)
+    (-> (desig:desig-prop ?delivering-location-designator (:in ?_))
+        (equal ?delivering-location-accessible NIL)
+        (equal ?delivering-location-accessible T))
     ;; deliver location robot base
     (-> (desig:desig-prop ?action-designator
                           (:deliver-robot-location ?some-d-robot-loc-desig))
@@ -275,5 +278,6 @@ the `look-pose-stamped'."
                                (:grasps ?grasps)
                                (:deliver-location ?delivering-location-designator)
                                (:deliver-robot-location ?deliver-robot-location-designator)
-                               (:search-location-accessible ?fetching-location-accessible))
+                               (:search-location-accessible ?fetching-location-accessible)
+                               (:delivery-location-accessible ?delivering-location-accessible))
                       ?resolved-action-designator)))

--- a/cram_pr2/cram_pr2_fetch_deliver_plans/src/fetch-and-deliver-plans.lisp
+++ b/cram_pr2/cram_pr2_fetch_deliver_plans/src/fetch-and-deliver-plans.lisp
@@ -544,6 +544,7 @@ If a failure happens, try a different `?target-location' or `?target-robot-locat
                     ((:deliver-location ?delivering-location))
                     ((:deliver-robot-location ?deliver-robot-location))
                     search-location-accessible
+                    delivery-location-accessible
                   &allow-other-keys)
   (unless search-location-accessible
     (exe:perform (desig:an action
@@ -609,14 +610,26 @@ If a failure happens, try a different `?target-location' or `?target-robot-locat
                       (drop-at-sink)
                       ;; (return)
                       ))
-                 (exe:perform (desig:an action
-                                        (type delivering)
-                                        (desig:when ?arm
-                                          (arm ?arm))
-                                        (object ?fetched-object)
-                                        (target ?delivering-location)
-                                        (robot-location ?deliver-robot-location)
-                                        (place-action ?deliver-place-action))))))))
+                 (unless delivery-location-accessible
+                   (exe:perform (desig:an action
+                                          (type accessing)
+                                          (location ?delivering-location)
+                                          (distance 0.3))))
+                 (unwind-protect
+                      (exe:perform (desig:an action
+                                             (type delivering)
+                                             (desig:when ?arm
+                                               (arm ?arm))
+                                             (object ?fetched-object)
+                                             (target ?delivering-location)
+                                             (robot-location ?deliver-robot-location)
+                                             (place-action ?deliver-place-action)))
+                   (unless delivery-location-accessible
+                     (exe:perform (desig:an action
+                                            (type sealing)
+                                            (location ?delivering-location)
+                                            (distance 0.3))))))))))
+         
 
     (unless search-location-accessible
       (exe:perform (desig:an action


### PR DESCRIPTION
1. Made costmap changes required to support objects inside containers using 'for' keyword for 'in' based 
   locations :- 
`(a location 
   (in (an object
           (type drawer)
           (urdf-name sink-area-upper-left-drawer-main)
           (part-of kitchen)))
   (for (an object 
            (type bowl))))`
2. Modified the 'transport' plan to support placing objects into inaccessible locations (containers)