### PR TITLE
Adding keyword "level" for containers

### DIFF
--- a/cram_3d_world/cram_btr_spatial_relations_costmap/src/cost-functions.lisp
+++ b/cram_3d_world/cram_btr_spatial_relations_costmap/src/cost-functions.lisp
@@ -405,7 +405,7 @@ if it is on the sign side of the axis. "
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; HEIGHT GENERATORS ;;;;;;;;;;;;;;;;;;;;;;;
 
-(defparameter *board-thickness* 0.035)
+(defparameter *board-thickness* 0.040)
 
 (defun make-object-bounding-box-height-generator (object &optional (tag :on))
   (constantly (list

--- a/cram_3d_world/cram_btr_spatial_relations_costmap/src/cost-functions.lisp
+++ b/cram_3d_world/cram_btr_spatial_relations_costmap/src/cost-functions.lisp
@@ -150,19 +150,24 @@ ref-sz/2 + ref-padding + max-padding + max-sz + max-padding + for-padding + for-
       (find-levels parent-link))
     levels-found))
 
-(defun choose-level (btr-environment level-links tag)
+(defun choose-level (btr-environment level-links tag &key (invert nil))
   (let* ((level-rigid-body-function (alexandria:compose
                                      (alexandria:curry
                                       #'get-link-rigid-body btr-environment)
                                      #'cl-urdf:name))
          (level-rigid-bodies (mapcar level-rigid-body-function level-links))
-         (search-index (case tag
+         (level-index (case tag
                          (:topmost (- (length level-rigid-bodies) 1))
                          (:bottommost 0)
-                         (otherwise (- tag 1)))))
+                         (otherwise (- tag 1))))
+         ;; Only need to reverse sort if the level specified is an integer
+         ;; since topmost and bottommost always means the same thing
+         (sort-order (if (and (typep tag 'integer)
+                              invert)
+                         #'> #'<)))
 
-    (nth search-index
-         (sort level-rigid-bodies #'> :key #'get-rigid-body-aabb-top-z))))
+    (nth level-index
+         (sort level-rigid-bodies sort-order :key #'get-rigid-body-aabb-top-z))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;; COSTMAPS ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cram_3d_world/cram_btr_spatial_relations_costmap/src/cost-functions.lisp
+++ b/cram_3d_world/cram_btr_spatial_relations_costmap/src/cost-functions.lisp
@@ -403,6 +403,26 @@ if it is on the sign side of the axis. "
             1.0
             0.0)))))
 
+(defun make-object-in-object-bounding-box-costmap-generator (container-object inner-object)
+  (let* ((bounding-box-dims (btr:calculate-bb-dims container-object))
+         (container-dimensions-x/2 (/ (cl-transforms:x bounding-box-dims) 2))
+         (container-dimensions-y/2 (/ (cl-transforms:y bounding-box-dims) 2))
+         (center-x (cl-transforms:x (cl-transforms:origin (btr:pose container-object))))
+         (center-y (cl-transforms:y (cl-transforms:origin (btr:pose container-object))))
+         (inner-obj-bb (btr:calculate-bb-dims inner-object))
+         (inner-obj-x/2 (/ (cl-transforms:x inner-obj-bb) 2))
+         (inner-obj-y/2 (/ (cl-transforms:y inner-obj-bb) 2))
+         (inner-obj-padding (max inner-obj-x/2 inner-obj-y/2))
+         (dimensions-x/2 (- container-dimensions-x/2 inner-obj-padding))
+         (dimensions-y/2 (- container-dimensions-y/2 inner-obj-padding)))
+    (lambda (x y)
+      (if (and
+           (< x (+ center-x dimensions-x/2))
+           (> x (- center-x dimensions-x/2))
+           (< y (+ center-y dimensions-y/2))
+           (> y (- center-y dimensions-y/2)))
+          1.0 0.0))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; HEIGHT GENERATORS ;;;;;;;;;;;;;;;;;;;;;;;
 
 (defparameter *board-thickness* 0.040)

--- a/cram_3d_world/cram_btr_spatial_relations_costmap/src/cost-functions.lisp
+++ b/cram_3d_world/cram_btr_spatial_relations_costmap/src/cost-functions.lisp
@@ -165,6 +165,7 @@ reverse sort it"
          (level-index (case tag
                          (:topmost (- (length level-rigid-bodies) 1))
                          (:bottommost 0)
+                         (:middle (floor (/ (length level-rigid-bodies) 2)))
                          (otherwise (- tag 1))))
          ;; Only need to reverse sort if the level specified is an integer
          ;; since topmost and bottommost always means the same thing

--- a/cram_3d_world/cram_btr_spatial_relations_costmap/src/cost-functions.lisp
+++ b/cram_3d_world/cram_btr_spatial_relations_costmap/src/cost-functions.lisp
@@ -156,11 +156,13 @@ ref-sz/2 + ref-padding + max-padding + max-sz + max-padding + for-padding + for-
                                       #'get-link-rigid-body btr-environment)
                                      #'cl-urdf:name))
          (level-rigid-bodies (mapcar level-rigid-body-function level-links))
-         (search-tag (ecase tag
-                       (:topmost #'>)
-                       (:bottommost #'<))))
-    (first (sort level-rigid-bodies search-tag
-                 :key #'get-rigid-body-aabb-top-z))))
+         (search-index (case tag
+                         (:topmost (- (length level-rigid-bodies) 1))
+                         (:bottommost 0)
+                         (otherwise (- tag 1)))))
+
+    (nth search-index
+         (sort level-rigid-bodies #'> :key #'get-rigid-body-aabb-top-z))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;; COSTMAPS ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cram_3d_world/cram_btr_spatial_relations_costmap/src/cost-functions.lisp
+++ b/cram_3d_world/cram_btr_spatial_relations_costmap/src/cost-functions.lisp
@@ -136,6 +136,8 @@ ref-sz/2 + ref-padding + max-padding + max-sz + max-padding + for-padding + for-
    (gethash container-name (cl-urdf:links (btr:urdf btr-environment)))))
 
 (defun find-levels-under-link (parent-link)
+  "Finds all the child links under the parent link with the name
+board or level in them"
   (let ((levels-found))
     (labels ((find-levels (link)
                (let* ((child-joints (cl-urdf:to-joints link))
@@ -151,6 +153,10 @@ ref-sz/2 + ref-padding + max-padding + max-sz + max-padding + for-padding + for-
     levels-found))
 
 (defun choose-level (btr-environment level-links tag &key (invert nil))
+  "Chooses the level based on the given tag which can be a number or a
+`:topmost' or `:bottommost' keyword. The sorting to find the level number
+usually sorted from the lowest level to the highest. The `invert' key will
+reverse sort it"
   (let* ((level-rigid-body-function (alexandria:compose
                                      (alexandria:curry
                                       #'get-link-rigid-body btr-environment)

--- a/cram_3d_world/cram_btr_spatial_relations_costmap/src/cost-functions.lisp
+++ b/cram_3d_world/cram_btr_spatial_relations_costmap/src/cost-functions.lisp
@@ -422,14 +422,25 @@ if it is on the sign side of the axis. "
                                2.0))
                          *board-thickness*))))))
 
-(defun make-object-on-object-bb-height-generator (environment-objects for-object)
+(defun make-object-on-object-bb-height-generator (environment-objects for-object
+                                                  &optional (tag :on))
   (let* ((environment-object-top
            (apply #'max
                   (mapcar (lambda (environment-object)
-                            (+ (cl-transforms:z
-                                (cl-transforms:origin (btr:pose environment-object)))
-                               (/ (cl-transforms:z (btr:calculate-bb-dims environment-object))
-                                  2.0)))
+                            (ecase tag
+                              (:on (+ (cl-transforms:z
+                                       (cl-transforms:origin
+                                        (btr:pose environment-object)))
+                                      (/ (cl-transforms:z
+                                          (btr:calculate-bb-dims environment-object))
+                                         2.0)))
+                              (:in (+ (cl-transforms:z
+                                       (cl-transforms:origin
+                                        (btr:pose environment-object)))
+                                      (- (/ (cl-transforms:z
+                                             (btr:calculate-bb-dims environment-object))
+                                            2.0))
+                                      *board-thickness*))))
                           (if (listp environment-objects)
                               environment-objects
                               (list environment-objects)))))

--- a/cram_3d_world/cram_btr_spatial_relations_costmap/src/prolog.lisp
+++ b/cram_3d_world/cram_btr_spatial_relations_costmap/src/prolog.lisp
@@ -390,6 +390,29 @@
      (make-object-on-object-bb-height-generator ?environment-link ?for-object-instance :on)
      ?costmap))
 
+;;;;;;;;;;;;;; LEVEL relationship for container type locations ;;;;;;;;;;;;;;;;;;;;;;;
+
+  (<- (get-level-rigid-body ?environment-object ?urdf-name ?level-relation
+                            ?level-rigid-body)
+    (member ?relation (:topmost :bottommost))
+    (lisp-fun get-level-links-in-container ?environment-object ?urdf-name ?child-levels)
+    (lisp-fun choose-level ?environment-object ?child-levels ?level-relation
+              ?level-rigid-body))
+
+  (<- (get-rigid-body ?designator ?link-rigid-body ?bounding-box-calculation-tag)
+    (or (desig:desig-prop ?designator (:on ?on-object))
+        (desig:desig-prop ?designator (:in ?on-object)))
+    (desig:desig-prop ?on-object (:urdf-name ?urdf-name))
+    (desig:desig-prop ?on-object (:part-of ?environment-name))
+    (btr:bullet-world ?world)
+    (btr:%object ?world ?environment-name ?environment-object)
+    (-> (desig:desig-prop ?on-object (:level ?relation))
+        (and (get-level-rigid-body ?environment-object ?urdf-name ?relation ?link-rigid-body)
+             (equal ?bounding-box-calculation-tag :on))
+        (and (lisp-fun get-link-rigid-body ?environment-object ?urdf-name ?link-rigid-body)
+             (lisp-pred identity ?link-rigid-body)
+             (equal ?bounding-box-calculation-tag :in))))
+
 ;;;;;;;;;;;;;;; spatial relation IN for environment objects ;;;;;;;;;;;;;;;;;;;
   (<- (costmap:desig-costmap ?designator ?costmap)
     (desig:desig-prop ?designator (:in ?object))
@@ -399,8 +422,7 @@
     (spec:property ?object (:part-of ?environment-name))
     (btr:bullet-world ?world)
     (btr:%object ?world ?environment-name ?environment)
-    (lisp-fun get-link-rigid-body ?environment ?urdf-name ?environment-link)
-    (lisp-pred identity ?environment-link)
+    (get-rigid-body ?designator ?environment-link ?bounding-box-calculation-tag)
     (costmap:costmap ?costmap)
     (costmap:costmap-add-function
      on-bounding-box
@@ -408,7 +430,8 @@
      ?costmap)
     (once (or (desig:desig-prop ?designator (:for ?_))
               (costmap:costmap-add-cached-height-generator
-               (make-object-bounding-box-height-generator ?environment-link :in)
+               (make-object-bounding-box-height-generator
+                ?environment-link ?bounding-box-calculation-tag)
                ?costmap)))
     (costmap:costmap-add-orientation-generator
      (make-discrete-orientations-generator)
@@ -423,8 +446,7 @@
     (costmap:costmap ?costmap)
     (btr:bullet-world ?world)
     (btr:%object ?world ?environment-name ?environment-object)
-    (lisp-fun get-link-rigid-body ?environment-object ?urdf-name ?environment-link)
-    (lisp-pred identity ?environment-link)
+    (get-rigid-body ?designator ?environment-link ?bounding-box-calculation-tag)
     (btr-belief:object-designator-name ?for-object ?for-object-name)
     (btr:%object ?world ?for-object-name ?for-object-instance)
     (costmap:costmap-add-function
@@ -433,7 +455,8 @@
       ?environment-link ?for-object-instance)
      ?costmap)
     (costmap:costmap-add-height-generator
-     (make-object-on-object-bb-height-generator ?environment-link ?for-object-instance :in)
+     (make-object-on-object-bb-height-generator
+      ?environment-link ?for-object-instance ?bounding-box-calculation-tag)
      ?costmap))
 
 ;;;;;;;;;;;;;; for TABLE-SETTING context ON (SLOTS) ;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cram_3d_world/cram_btr_spatial_relations_costmap/src/prolog.lisp
+++ b/cram_3d_world/cram_btr_spatial_relations_costmap/src/prolog.lisp
@@ -394,7 +394,8 @@
 
   (<- (get-level-rigid-body ?environment-object ?urdf-name ?level-relation
                             ?level-rigid-body)
-    (member ?relation (:topmost :bottommost))
+    (or (member ?level-relation (:topmost :bottommost))
+        (lisp-pred typep ?level-relation integer))
     (lisp-fun get-level-links-in-container ?environment-object ?urdf-name ?child-levels)
     (lisp-fun choose-level ?environment-object ?child-levels ?level-relation
               ?level-rigid-body))

--- a/cram_3d_world/cram_btr_spatial_relations_costmap/src/prolog.lisp
+++ b/cram_3d_world/cram_btr_spatial_relations_costmap/src/prolog.lisp
@@ -410,7 +410,7 @@
      (make-object-bounding-box-height-generator ?environment-link :in)
      ?costmap))
 
-    (<- (costmap:desig-costmap ?designator ?costmap)
+  (<- (costmap:desig-costmap ?designator ?costmap)
     (desig:desig-prop ?designator (:in ?object))
     (spec:property ?object (:type ?object-type))
     (man-int:object-type-subtype :container ?object-type)

--- a/cram_3d_world/cram_btr_spatial_relations_costmap/src/prolog.lisp
+++ b/cram_3d_world/cram_btr_spatial_relations_costmap/src/prolog.lisp
@@ -394,7 +394,7 @@
 
   (<- (get-level-rigid-body ?environment-object ?urdf-name ?level-relation
                             ?invert ?level-rigid-body)
-    (or (member ?level-relation (:topmost :bottommost))
+    (or (member ?level-relation (:topmost :bottommost :middle))
         (lisp-pred typep ?level-relation integer))
     (lisp-fun get-level-links-in-container
               ?environment-object ?urdf-name ?child-levels)

--- a/cram_3d_world/cram_btr_spatial_relations_costmap/src/prolog.lisp
+++ b/cram_3d_world/cram_btr_spatial_relations_costmap/src/prolog.lisp
@@ -406,25 +406,6 @@
      on-bounding-box
      (make-object-bounding-box-costmap-generator ?environment-link)
      ?costmap)
-    (costmap:costmap-add-cached-height-generator
-     (make-object-bounding-box-height-generator ?environment-link :in)
-     ?costmap))
-
-  (<- (costmap:desig-costmap ?designator ?costmap)
-    (desig:desig-prop ?designator (:in ?object))
-    (spec:property ?object (:type ?object-type))
-    (man-int:object-type-subtype :container ?object-type)
-    (spec:property ?object (:urdf-name ?urdf-name))
-    (spec:property ?object (:part-of ?environment-name))
-    (btr:bullet-world ?world)
-    (btr:%object ?world ?environment-name ?environment)
-    (lisp-fun get-link-rigid-body ?environment ?urdf-name ?environment-link)
-    (lisp-pred identity ?environment-link)
-    (costmap:costmap ?costmap)
-    (costmap:costmap-add-function
-     on-bounding-box
-     (make-object-bounding-box-costmap-generator ?environment-link)
-     ?costmap)
     (once (or (desig:desig-prop ?designator (:for ?_))
               (costmap:costmap-add-cached-height-generator
                (make-object-bounding-box-height-generator ?environment-link :in)
@@ -446,6 +427,11 @@
     (lisp-pred identity ?environment-link)
     (btr-belief:object-designator-name ?for-object ?for-object-name)
     (btr:%object ?world ?for-object-name ?for-object-instance)
+    (costmap:costmap-add-function
+     on-bounding-box
+     (make-object-in-object-bounding-box-costmap-generator
+      ?environment-link ?for-object-instance)
+     ?costmap)
     (costmap:costmap-add-height-generator
      (make-object-on-object-bb-height-generator ?environment-link ?for-object-instance :in)
      ?costmap))

--- a/cram_3d_world/cram_btr_spatial_relations_costmap/src/prolog.lisp
+++ b/cram_3d_world/cram_btr_spatial_relations_costmap/src/prolog.lisp
@@ -373,7 +373,7 @@
      (make-discrete-orientations-generator)
      ?costmap))
 
-;; height generator for locations ((on something) (name something) (for some-obj))
+;; height generator for locations ((on something) (for some-obj))
   (<- (costmap:desig-costmap ?designator ?costmap)
     (desig:desig-prop ?designator (:for ?for-object))
     (desig:desig-prop ?designator (:on ?on-object))
@@ -387,7 +387,7 @@
     (btr-belief:object-designator-name ?for-object ?for-object-name)
     (btr:%object ?world ?for-object-name ?for-object-instance)
     (costmap:costmap-add-height-generator
-     (make-object-on-object-bb-height-generator ?environment-link ?for-object-instance)
+     (make-object-on-object-bb-height-generator ?environment-link ?for-object-instance :on)
      ?costmap))
 
 ;;;;;;;;;;;;;;; spatial relation IN for environment objects ;;;;;;;;;;;;;;;;;;;
@@ -408,6 +408,46 @@
      ?costmap)
     (costmap:costmap-add-cached-height-generator
      (make-object-bounding-box-height-generator ?environment-link :in)
+     ?costmap))
+
+    (<- (costmap:desig-costmap ?designator ?costmap)
+    (desig:desig-prop ?designator (:in ?object))
+    (spec:property ?object (:type ?object-type))
+    (man-int:object-type-subtype :container ?object-type)
+    (spec:property ?object (:urdf-name ?urdf-name))
+    (spec:property ?object (:part-of ?environment-name))
+    (btr:bullet-world ?world)
+    (btr:%object ?world ?environment-name ?environment)
+    (lisp-fun get-link-rigid-body ?environment ?urdf-name ?environment-link)
+    (lisp-pred identity ?environment-link)
+    (costmap:costmap ?costmap)
+    (costmap:costmap-add-function
+     on-bounding-box
+     (make-object-bounding-box-costmap-generator ?environment-link)
+     ?costmap)
+    (once (or (desig:desig-prop ?designator (:for ?_))
+              (costmap:costmap-add-cached-height-generator
+               (make-object-bounding-box-height-generator ?environment-link :in)
+               ?costmap)))
+    (costmap:costmap-add-orientation-generator
+     (make-discrete-orientations-generator)
+     ?costmap))
+
+;; height generator for locations ((in something) (for some-obj))
+  (<- (costmap:desig-costmap ?designator ?costmap)
+    (desig:desig-prop ?designator (:for ?for-object))
+    (desig:desig-prop ?designator (:in ?in-object))
+    (desig:desig-prop ?in-object (:urdf-name ?urdf-name))
+    (desig:desig-prop ?in-object (:part-of ?environment-name))
+    (costmap:costmap ?costmap)
+    (btr:bullet-world ?world)
+    (btr:%object ?world ?environment-name ?environment-object)
+    (lisp-fun get-link-rigid-body ?environment-object ?urdf-name ?environment-link)
+    (lisp-pred identity ?environment-link)
+    (btr-belief:object-designator-name ?for-object ?for-object-name)
+    (btr:%object ?world ?for-object-name ?for-object-instance)
+    (costmap:costmap-add-height-generator
+     (make-object-on-object-bb-height-generator ?environment-link ?for-object-instance :in)
      ?costmap))
 
 ;;;;;;;;;;;;;; for TABLE-SETTING context ON (SLOTS) ;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cram_3d_world/cram_bullet_reasoning_belief_state/src/event-handlers.lisp
+++ b/cram_3d_world/cram_bullet_reasoning_belief_state/src/event-handlers.lisp
@@ -71,7 +71,7 @@ If there is no other method with 1 as qualifier, this method will be executed al
     (when (cut:is-var link) (error "[BTR-BELIEF OBJECT-DETACHED] Couldn't find robot's EE link."))
     (when btr-object
       (btr:detach-object robot-object btr-object link)
-      (btr:simulate btr:*current-bullet-world* 100)
+      (btr:simulate btr:*current-bullet-world* 10)
       ;; finding the link that supports the object now
       (let ((environment-object (btr:get-environment-object))
             (environment-link (cut:var-value
@@ -80,9 +80,9 @@ If there is no other method with 1 as qualifier, this method will be executed al
                                   `(and (btr:bullet-world ?world)
                                         (btr:supported-by
                                          ?world ,btr-object-name ?env-name ?env-link)))))))
-        (when (cut:is-var environment-link)
-          (error "[BTR-BELIEF OBJECT-DETACHED] Couldn't find the link supporting ~a" btr-object-name))
-        (btr:attach-object environment-object btr-object environment-link)))))
+        ;; attaching the link to the object if it finds one.
+        (unless (cut:is-var environment-link)
+          (btr:attach-object environment-object btr-object environment-link))))))
 
 #+implement-this-when-object-to-object-is-implemented
 (defmethod cram-occasions-events:on-event btr-attach-two-objs ((event cpoe:object-attached-object))

--- a/cram_3d_world/cram_bullet_reasoning_belief_state/src/event-handlers.lisp
+++ b/cram_3d_world/cram_bullet_reasoning_belief_state/src/event-handlers.lisp
@@ -71,7 +71,18 @@ If there is no other method with 1 as qualifier, this method will be executed al
     (when (cut:is-var link) (error "[BTR-BELIEF OBJECT-DETACHED] Couldn't find robot's EE link."))
     (when btr-object
       (btr:detach-object robot-object btr-object link)
-      (btr:simulate btr:*current-bullet-world* 10))))
+      (btr:simulate btr:*current-bullet-world* 100)
+      ;; finding the link that supports the object now
+      (let ((environment-object (btr:get-environment-object))
+            (environment-link (cut:var-value
+                            '?env-link
+                            (car (prolog:prolog
+                                  `(and (btr:bullet-world ?world)
+                                        (btr:supported-by
+                                         ?world ,btr-object-name ?env-name ?env-link)))))))
+        (when (cut:is-var environment-link)
+          (error "[BTR-BELIEF OBJECT-DETACHED] Couldn't find the link supporting ~a" btr-object-name))
+        (btr:attach-object environment-object btr-object environment-link)))))
 
 #+implement-this-when-object-to-object-is-implemented
 (defmethod cram-occasions-events:on-event btr-attach-two-objs ((event cpoe:object-attached-object))

--- a/cram_pr2/cram_pr2_fetch_deliver_plans/src/fetch-and-deliver-designators.lisp
+++ b/cram_pr2/cram_pr2_fetch_deliver_plans/src/fetch-and-deliver-designators.lisp
@@ -257,6 +257,9 @@ the `look-pose-stamped'."
                    (:target ?some-delivering-location-designator))
     (desig:current-designator ?some-delivering-location-designator
                               ?delivering-location-designator)
+    (-> (desig:desig-prop ?delivering-location-designator (:in ?_))
+        (equal ?delivering-location-accessible NIL)
+        (equal ?delivering-location-accessible T))
     ;; deliver location robot base
     (-> (desig:desig-prop ?action-designator
                           (:deliver-robot-location ?some-d-robot-loc-desig))
@@ -275,5 +278,6 @@ the `look-pose-stamped'."
                                (:grasps ?grasps)
                                (:deliver-location ?delivering-location-designator)
                                (:deliver-robot-location ?deliver-robot-location-designator)
-                               (:search-location-accessible ?fetching-location-accessible))
+                               (:search-location-accessible ?fetching-location-accessible)
+                               (:delivery-location-accessible ?delivering-location-accessible))
                       ?resolved-action-designator)))

--- a/cram_pr2/cram_pr2_fetch_deliver_plans/src/fetch-and-deliver-plans.lisp
+++ b/cram_pr2/cram_pr2_fetch_deliver_plans/src/fetch-and-deliver-plans.lisp
@@ -544,6 +544,7 @@ If a failure happens, try a different `?target-location' or `?target-robot-locat
                     ((:deliver-location ?delivering-location))
                     ((:deliver-robot-location ?deliver-robot-location))
                     search-location-accessible
+                    delivery-location-accessible
                   &allow-other-keys)
   (unless search-location-accessible
     (exe:perform (desig:an action
@@ -609,14 +610,26 @@ If a failure happens, try a different `?target-location' or `?target-robot-locat
                       (drop-at-sink)
                       ;; (return)
                       ))
-                 (exe:perform (desig:an action
-                                        (type delivering)
-                                        (desig:when ?arm
-                                          (arm ?arm))
-                                        (object ?fetched-object)
-                                        (target ?delivering-location)
-                                        (robot-location ?deliver-robot-location)
-                                        (place-action ?deliver-place-action))))))))
+                 (unless delivery-location-accessible
+                   (exe:perform (desig:an action
+                                          (type accessing)
+                                          (location ?delivering-location)
+                                          (distance 0.3))))
+                 (unwind-protect
+                      (exe:perform (desig:an action
+                                             (type delivering)
+                                             (desig:when ?arm
+                                               (arm ?arm))
+                                             (object ?fetched-object)
+                                             (target ?delivering-location)
+                                             (robot-location ?deliver-robot-location)
+                                             (place-action ?deliver-place-action)))
+                   (unless delivery-location-accessible
+                     (exe:perform (desig:an action
+                                            (type sealing)
+                                            (location ?delivering-location)
+                                            (distance 0.3))))))))))
+         
 
     (unless search-location-accessible
       (exe:perform (desig:an action


### PR DESCRIPTION
**Prerequisite**
The container should have URDF child links with "drawer" or "level" in their names

**Example**
` (a location (in (an object
                             (type container)
                             (urdf-name iai-fridge-main)
                             (part-of kitchen)
                             (level topmost))))))`
**Features**
1. Supported values for the level keyword are :topmost, :bottommost, :middle or the number of the tray you want to access. 
2. The numbering of the trays starts from 1 and is normally numbered from bottom up.
3. If you want the numbering to be considered top-down use `level-invert` instead of `level`
4. In both `level` and `level` invert `:topmost` and `:bottommost` still means the same tray and is independent of the numbering.

**Changes**
Added the keyword and changed the prolog rules and cost functions for it.

**Notes**
At the time of the creation of this PR, it has a dependency on  [this pull request](https://github.com/cram2/cram/pull/106) and thus has changes that should go in prior to this PR in it.
Also, It has to be noted that to test this change, the urdf of the iai_maps for fridge has to be changed. A pull request for that has not been created at this point in time.