### PR TITLE
Attachments for items and generalization from methods attach-object, detach-object ...

### DIFF
--- a/cram_3d_world/cram_bullet_reasoning/src/objects.lisp
+++ b/cram_3d_world/cram_bullet_reasoning/src/objects.lisp
@@ -140,6 +140,15 @@
     (loop for key being the hash-keys in rigid-bodies do
       (setf (gethash key rigid-bodies) nil))))
 
+(defgeneric attach-object (attach-to-obj obj &key &allow-other-keys) 
+  (:documentation "Adds `obj' to the set of attached objects."))
+
+(defgeneric detach-object (obj detach-obj &key &allow-other-keys)
+  (:documentation "Detaches `obj' from the set of attached objects."))
+
+(defgeneric detach-all-objects (obj)
+  (:documentation "Removes all objects form the list of attached objects."))
+
 (defmethod pose ((object object))
   "Returns the pose of the object, i.e. the pose of the body named by
   the slot `pose-reference-body'"


### PR DESCRIPTION
The code from grasping.lisp and placing.lisp are now in assembly.lisp [here](https://github.com/tlipps/cram/commit/2b6ffe95ac35443b6d46431e64f11aad9eb17dce#diff-41). Only shown here as a link, because it was edited in in a merge commit.