### PR TITLE
Add helper function for calling generic functions with most specific object-type

### DIFF
--- a/cram_common/cram_manipulation_interfaces/src/gripper.lisp
+++ b/cram_common/cram_manipulation_interfaces/src/gripper.lisp
@@ -30,27 +30,7 @@
 (in-package :cram-manipulation-interfaces)
 
 (defmethod get-action-gripping-effort :heuristics 20 (object-type)
-  (let ((specific-type
-          (find-most-specific-object-type-for-generic
-           #'get-action-gripping-effort object-type)))
-    (if specific-type
-        (get-action-gripping-effort specific-type)
-        (error "There is no applicable method for the generic function ~%~a~%~
-                with object-type ~a.~%To fix this either: ~
-                ~%- Add a method with (object-type (eql ~a)) as the first specializer or ~
-                ~%- Add ~a into the type hierarchy in the cram_object_knowledge package."
-               #'get-action-gripping-effort
-               object-type object-type object-type))))
+  (call-with-specific-type #'get-action-gripping-effort object-type))
 
 (defmethod get-action-gripper-opening :heuristics 20 (object-type)
-  (let ((specific-type
-          (find-most-specific-object-type-for-generic
-           #'get-action-gripper-opening object-type)))
-    (if specific-type
-        (get-action-gripper-opening specific-type)
-        (error "There is no applicable method for the generic function ~%~a~%~
-                with object-type ~a.~%To fix this either: ~
-                ~%- Add a method with (object-type (eql ~a)) as the first specializer or ~
-                ~%- Add ~a into the type hierarchy in the cram_object_knowledge package."
-               #'get-action-gripper-opening
-               object-type object-type object-type))))
+  (call-with-specific-type #'get-action-gripper-opening object-type))

--- a/cram_common/cram_manipulation_interfaces/src/manipulation-interfaces.lisp
+++ b/cram_common/cram_manipulation_interfaces/src/manipulation-interfaces.lisp
@@ -84,3 +84,19 @@ make CRAM_DESIGNATORS package depend on CRAM_MANIPULATION_INTERFACES,
 and man-int is way too high level to make it a dependency of CRAM_CORE.
 This hijacking is kind of an ugly hack that Gaya feels bad about :(."
   (get-location-poses desig))
+
+(defun call-with-specific-type (fun object-type &rest args)
+  "Call generic function FUN with the most specific type for OBJECT-TYPE. Have
+to provide all arguments for fun after object-type in the correct order."
+  (let ((specific-type
+            (find-most-specific-object-type-for-generic
+             fun object-type)))
+      (if specific-type
+          ;; (get-object-type-to-gripper-transform specific-type object-name arm grasp)
+          (apply (alexandria:curry fun specific-type) args)
+          (error "There is no applicable method for the generic function ~%~a~%~
+                  with object-type ~a.~%To fix this either: ~
+                  ~%- Add a method with (object-type (eql ~a)) as the first specializer or ~
+                  ~%- Add ~a into the type hierarchy in the cram_object_knowledge package."
+                 fun
+                 object-type object-type object-type))))

--- a/cram_common/cram_manipulation_interfaces/src/trajectories.lisp
+++ b/cram_common/cram_manipulation_interfaces/src/trajectories.lisp
@@ -87,22 +87,6 @@
 (defvar *known-grasp-types* nil
   "A list of symbols representing all known grasp types")
 
-(defun call-with-specific-type (fun object-type &rest args)
-  "Call generic function FUN with the most specific type for OBJECT-TYPE. Have
-to provide all arguments for fun after object-type in the correct order."
-  (let ((specific-type
-            (find-most-specific-object-type-for-generic
-             fun object-type)))
-      (if specific-type
-          ;; (get-object-type-to-gripper-transform specific-type object-name arm grasp)
-          (apply (alexandria:curry fun specific-type) args)
-          (error "There is no applicable method for the generic function ~%~a~%~
-                  with object-type ~a.~%To fix this either: ~
-                  ~%- Add a method with (object-type (eql ~a)) as the first specializer or ~
-                  ~%- Add ~a into the type hierarchy in the cram_object_knowledge package."
-                 fun
-                 object-type object-type object-type))))
-
 (defgeneric get-object-type-to-gripper-transform (object-type object-name arm grasp)
   (:documentation "Returns a pose stamped.
 Gripper is defined by a convention where Z is pointing towards the object.")

--- a/cram_common/cram_manipulation_interfaces/src/trajectories.lisp
+++ b/cram_common/cram_manipulation_interfaces/src/trajectories.lisp
@@ -87,89 +87,56 @@
 (defvar *known-grasp-types* nil
   "A list of symbols representing all known grasp types")
 
-(defgeneric get-object-type-to-gripper-transform (object-type object-name arm grasp)
-  (:documentation "Returns a pose stamped.
-Gripper is defined by a convention where Z is pointing towards the object.")
-  (:method (object-type object-name arm grasp)
-    (let ((specific-type
+(defun call-with-specific-type (fun object-type &rest args)
+  "Call generic function FUN with the most specific type for OBJECT-TYPE. Have
+to provide all arguments for fun after object-type in the correct order."
+  (let ((specific-type
             (find-most-specific-object-type-for-generic
-             #'get-object-type-to-gripper-transform object-type)))
+             fun object-type)))
       (if specific-type
-          (get-object-type-to-gripper-transform specific-type object-name arm grasp)
+          ;; (get-object-type-to-gripper-transform specific-type object-name arm grasp)
+          (apply (alexandria:curry fun specific-type) args)
           (error "There is no applicable method for the generic function ~%~a~%~
                   with object-type ~a.~%To fix this either: ~
                   ~%- Add a method with (object-type (eql ~a)) as the first specializer or ~
                   ~%- Add ~a into the type hierarchy in the cram_object_knowledge package."
-                 #'get-object-type-to-gripper-transform
-                 object-type object-type object-type)))))
+                 fun
+                 object-type object-type object-type))))
+
+(defgeneric get-object-type-to-gripper-transform (object-type object-name arm grasp)
+  (:documentation "Returns a pose stamped.
+Gripper is defined by a convention where Z is pointing towards the object.")
+  (:method (object-type object-name arm grasp)
+    (call-with-specific-type #'get-object-type-to-gripper-transform
+                             object-type object-name arm grasp)))
 
 (defgeneric get-object-type-to-gripper-pregrasp-transform (object-type object-name
                                                            arm grasp grasp-transform)
   (:documentation "Returns a transform stamped")
   (:method (object-type object-name arm grasp grasp-transform)
-    (let ((specific-type
-            (find-most-specific-object-type-for-generic
-             #'get-object-type-to-gripper-pregrasp-transform object-type)))
-      (if specific-type
-          (get-object-type-to-gripper-pregrasp-transform
-           specific-type object-name arm grasp grasp-transform)
-          (error "There is no applicable method for the generic function ~%~a~%~
-                  with object-type ~a.~%To fix this either: ~
-                  ~%- Add a method with (object-type (eql ~a)) as the first specializer or ~
-                  ~%- Add ~a into the type hierarchy in the cram_object_knowledge package."
-                 #'get-object-type-to-gripper-pregrasp-transform
-                 object-type object-type object-type)))))
+    (call-with-specific-type #'get-object-type-to-gripper-pregrasp-transform
+                             object-type object-name arm grasp grasp-transform)))
 
 (defgeneric get-object-type-to-gripper-2nd-pregrasp-transform (object-type object-name
                                                                arm grasp grasp-transform)
   (:documentation "Returns a transform stamped. Default value is NIL.")
   (:method (object-type object-name arm grasp grasp-transform)
-    (let ((specific-type
-            (find-most-specific-object-type-for-generic
-             #'get-object-type-to-gripper-2nd-pregrasp-transform object-type)))
-      (if specific-type
-          (get-object-type-to-gripper-2nd-pregrasp-transform
-           specific-type object-name arm grasp grasp-transform)
-          (error "There is no applicable method for the generic function ~%~a~%~
-                  with object-type ~a.~%To fix this either: ~
-                  ~%- Add a method with (object-type (eql ~a)) as the first specializer or ~
-                  ~%- Add ~a into the type hierarchy in the cram_object_knowledge package."
-                 #'get-object-type-to-gripper-2nd-pregrasp-transform
-                 object-type object-type object-type)))))
+    (call-with-specific-type #'get-object-type-to-gripper-2nd-pregrasp-transform
+                             object-type object-name arm grasp grasp-transform)))
 
 (defgeneric get-object-type-to-gripper-lift-transform (object-type object-name
                                                        arm grasp grasp-transform)
   (:documentation "Returns a transform stamped")
   (:method (object-type object-name arm grasp grasp-transform)
-    (let ((specific-type
-            (find-most-specific-object-type-for-generic
-             #'get-object-type-to-gripper-lift-transform object-type)))
-      (if specific-type
-          (get-object-type-to-gripper-lift-transform
-           specific-type object-name arm grasp grasp-transform)
-          (error "There is no applicable method for the generic function ~%~a~%~
-                  with object-type ~a.~%To fix this either: ~
-                  ~%- Add a method with (object-type (eql ~a)) as the first specializer or ~
-                  ~%- Add ~a into the type hierarchy in the cram_object_knowledge package."
-                 #'get-object-type-to-gripper-lift-transform
-                 object-type object-type object-type)))))
+    (call-with-specific-type #'get-object-type-to-gripper-lift-transform
+                             object-type object-name arm grasp grasp-transform)))
 
 (defgeneric get-object-type-to-gripper-2nd-lift-transform (object-type object-name
                                                            arm grasp grasp-transform)
   (:documentation "Returns a transform stamped")
   (:method (object-type object-name arm grasp grasp-transform)
-    (let ((specific-type
-            (find-most-specific-object-type-for-generic
-             #'get-object-type-to-gripper-2nd-lift-transform object-type)))
-      (if specific-type
-          (get-object-type-to-gripper-2nd-lift-transform
-           specific-type object-name arm grasp grasp-transform)
-          (error "There is no applicable method for the generic function ~%~a~%~
-                  with object-type ~a.~%To fix this either: ~
-                  ~%- Add a method with (object-type (eql ~a)) as the first specializer or ~
-                  ~%- Add ~a into the type hierarchy in the cram_object_knowledge package."
-                 #'get-object-type-to-gripper-2nd-lift-transform
-                 object-type object-type object-type)))))
+    (call-with-specific-type #'get-object-type-to-gripper-2nd-lift-transform
+                             object-type object-name arm grasp grasp-transform)))
 
 
 (defmacro def-object-type-to-gripper-transforms (object-type arm grasp-type


### PR DESCRIPTION
Just what the title says. Adds a simple defun to trajectories.lisp that encapsules the call to find-most-specific-object-type-for-generic and the associate error handling.