### PR TITLE
Fix get connecting joint

### DIFF
--- a/cram_pr2/cram_pr2_environment_manipulation/cram-pr2-environment-manipulation.asd
+++ b/cram_pr2/cram_pr2_environment_manipulation/cram-pr2-environment-manipulation.asd
@@ -65,6 +65,6 @@
      (:file "math" :depends-on ("package"))
      (:file "environment" :depends-on ("package"))
      (:file "costmaps" :depends-on ("package" "math" "environment"))
-     (:file "trajectories" :depends-on ("package"))
+     (:file "trajectories" :depends-on ("package" "environment"))
      (:file "action-designators" :depends-on ("package" "trajectories"))
      (:file "plans" :depends-on ("package" "environment"))))))

--- a/cram_pr2/cram_pr2_environment_manipulation/src/action-designators.lisp
+++ b/cram_pr2/cram_pr2_environment_manipulation/src/action-designators.lisp
@@ -29,21 +29,6 @@
 
 (in-package :pr2-em)
 
-(defun get-container-pose-and-transform (name btr-environment)
-  "Return a list of the pose-stamped and transform-stamped of the object named
-NAME in the environment BTR-ENVIRONMENT."
-  (let* ((name-rosified (roslisp-utilities:rosify-underscores-lisp-name name))
-         (urdf-pose (get-urdf-link-pose name-rosified btr-environment))
-         (pose (cram-tf:ensure-pose-in-frame
-                (cl-transforms-stamped:pose->pose-stamped
-                 cram-tf:*fixed-frame*
-                 0.0
-                 urdf-pose)
-                cram-tf:*robot-base-frame*
-                :use-zero-time t))
-         (transform (cram-tf:pose-stamped->transform-stamped pose name-rosified)))
-    (list pose transform)))
-
 (def-fact-group environment-manipulation (desig:action-grounding)
 
   (<- (desig:action-grounding ?action-designator (open-container ?referenced-action-designator))

--- a/cram_pr2/cram_pr2_environment_manipulation/src/trajectories.lisp
+++ b/cram_pr2/cram_pr2_environment_manipulation/src/trajectories.lisp
@@ -81,11 +81,15 @@ This should only be used by get-action-trajectory for action-types :opening and 
            (desig:desig-prop-value object-designator :type))
          (object-environment
            (desig:desig-prop-value object-designator :part-of))
+         (manipulated-link-name
+           (cl-urdf:name
+            (get-manipulated-link
+             (get-container-link object-name object-environment))))
          (object-transform
            (second
-            (get-container-pose-and-transform object-name object-environment)))
+            (get-container-pose-and-transform manipulated-link-name object-environment)))
          (grasp-pose
-           (get-container-to-gripper-transform object-name arm handle-axis object-environment)))
+           (get-container-to-gripper-transform manipulated-link-name arm handle-axis object-environment)))
 
     ;; checks if `object-type' is a subtype of :container-prismatic or :container-revolute
     ;; and executes the corresponding MAKE-PRISMATIC-TRAJECTORY or MAKE-REVOLUTE-TRAJECTORY.
@@ -198,9 +202,10 @@ container with revolute joints."
                                            handle-axis
                                            btr-environment)
   "Get the transform from the container handle to the robot's gripper."
-  (let* ((object-name
-           (roslisp-utilities:rosify-underscores-lisp-name object-name))
-         (handle-name
+  (when (symbolp object-name)
+    (setf object-name
+          (roslisp-utilities:rosify-underscores-lisp-name object-name)))
+  (let* ((handle-name
            (cl-urdf:name (get-handle-link object-name btr-environment)))
          (handle-tf
            (cl-transforms-stamped:transform->transform-stamped


### PR DESCRIPTION
Before, the joint which was to be manipulated was only searched for above the container-link of the given container. That was why to open the fridge one had to open the fridge-door.
Now, the responsible function searches in both directions to find the joint.

Implements card: https://trello.com/c/ySe4BT5V

Example with fridge:

```lisp
(pr2-proj:with-projected-robot
    (perform (an action
                 (type opening)
                 (arm left)
                 (distance 0.3)
                 (object (an object
                             (type drawer)
                             (part-of kitchen)
                             (urdf-name iai_fridge_main))))))
```


Example with fridge-door:

```lisp
(pr2-proj:with-projected-robot
    (perform (an action
                 (type opening)
                 (arm left)
                 (distance 0.3)
                 (object (an object
                             (type drawer)
                             (part-of kitchen)
                             (urdf-name iai_fridge_door))))))
```