### PR TITLE
Added the keyword 'orientation' for location designators

### DIFF
--- a/cram_3d_world/cram_btr_spatial_relations_costmap/src/cost-functions.lisp
+++ b/cram_3d_world/cram_btr_spatial_relations_costmap/src/cost-functions.lisp
@@ -537,7 +537,7 @@ if it is on the sign side of the axis. "
    perpendicular to the edge of the supporting object, to which _pose_ is the closest.
    If `ref-obj-dependent' is t then _pose_ will be `ref-obj-pose',
    otherwise it will be defined by (x, y)."
-  (declare (type cl-transforms:pose supp-obj-pose ref-obj-pose)
+  (declare (type cl-transforms:pose supp-obj-pose)
            (type cl-transforms:3d-vector supp-obj-dims)
            (type boolean ref-obj-dependent))
   (let* ((pose
@@ -564,11 +564,33 @@ if it is on the sign side of the axis. "
       (setf supp-angle (- (* 2 pi) supp-angle)))
     (+ supp-angle angle-in-supp)))
 
-(defun make-discrete-orientations-generator ()
+(defun make-supporting-obj-aligned-orientations-generator (supp-obj-dims supp-obj-pose
+                                                           supp-obj-z &optional ref-obj-pose)
+  "Generates orientations around z axis which is aligned to the edge of the supporting
+object. The edge selected is dependent on the pose in consideration or the pose of a
+reference object (which is optional but has priority)."
+  (lambda (x y previous-orientations)
+    (declare (ignore previous-orientations))
+    (let* ((ref-obj-dependent (not (null ref-obj-pose)))
+           (aligned-direction (supporting-obj-aligned-direction
+                               x y supp-obj-pose supp-obj-dims supp-obj-z
+                               :ref-obj-dependent ref-obj-dependent
+                               :ref-obj-pose ref-obj-pose)))
+      (list
+       (cl-transforms:axis-angle->quaternion (cl-transforms:make-3d-vector 0 0 1)
+                                             aligned-direction)))))
+
+(defun make-z-orientations-generator (tag &key (samples 4))
+  "Generates orientations around z axis randomly or along the cardinal directions
+according to the tag provided. Cardinal directions only support 4 samples. If random
+sampling is used the number of samples can be modified through the optional samples tag."
   (lambda (x y previous-orientations)
     (declare (ignore x y previous-orientations))
     (cut:lazy-mapcar (lambda (angle)
                        (cl-transforms:axis-angle->quaternion
                         (cl-transforms:make-3d-vector 0 0 1)
                         angle))
-                     `(0.0 ,pi ,(/ pi 2) ,(- (/ pi 2))))))
+                     (ecase tag
+                       (:random (loop for i from 1 to samples
+                                      collect (random (* 2 pi))))
+                       (:cardinal `(0.0 ,pi ,(/ pi 2) ,(- (/ pi 2))))))))


### PR DESCRIPTION
[Link to Trello Card](https://trello.com/c/1GLWZcfA)
1. orientation supports :aligned :random and :cardinal
2. Default orientaton used now is :random and can be changed individually. 
3. :cardinal gives orientations along the xy axes
4. :aligned gives orientations perpendicular to the supporting object

Usage examles:

- `(a location (on (an object 
                          (type counter-top)
                          (urdf-name sink-area-surface)
                          (part-of kitchen)))
         (orientation aligned))`

- `(desig:a location
               (right-of (an object (type bowl)))
               (near (an object (type bowl)))
               (for (an object (type spoon)))
               (orientation aligned))`

Tried using this with the demo code and now the robot can successfully place the spoon aligned with the bowl rather than it being the opposite way around by providing the location designator mentioned above.