### PR TITLE
[fd-plans]Supporting 'dropping' action designator 

### DIFF
--- a/cram_3d_world/cram_fetch_deliver_plans/src/fetch-and-deliver-plans.lisp
+++ b/cram_3d_world/cram_fetch_deliver_plans/src/fetch-and-deliver-plans.lisp
@@ -492,7 +492,19 @@ If a failure happens, try a different `?target-location' or `?target-robot-locat
                     (proj-reasoning:check-placing-pose-stability
                      ?object-designator ?target-location))
 
-                  (exe:perform place-action))))))))))
+                  (exe:perform place-action)
+                  ;; Hacky workaround for gravity bug
+                  ;; Teleporting all objects that are dropped to below the floor to avoid
+                  ;; them causing occlusions and obstructions in the bullet world.
+                  (if (equal ?delivery-type :dropping)
+                      (progn
+                        (let* ((?obj-name (desig:desig-prop-value ?object-designator :name))
+                               (?obj-pose (btr:pose (btr:object btr:*current-bullet-world*
+                                                                ?obj-name))))
+                          (btr-utils:move-object ?obj-name
+                                                 (cram-tf:translate-pose
+                                                  ?obj-pose
+                                                  :z-offset -3.0))))))))))))))
 
 
 


### PR DESCRIPTION
_None of the keywords and names in this plan are confirmed and I don't expect it to be used in the final code. Will look for Gaya's suggestions on what to rename these keywords to._

This action primarily disables the stability check in the end of the deliver plan.
The deliver plan otherwise is completely the same and is reused for the dropping action
Additionally, the transport plan has been modified to also include a mode transport-and-drop(name to be changed to something appropriate) which will use the action 'dropping' instead of 'delivering'.