### PR TITLE
[env-man] Fixes for distance revision

### DIFF
--- a/cram_3d_world/cram_bullet_reasoning_belief_state/src/event-handlers.lisp
+++ b/cram_3d_world/cram_bullet_reasoning_belief_state/src/event-handlers.lisp
@@ -146,7 +146,6 @@ If there is no other method with 1 as qualifier, this method will be executed al
 
 
 (defun move-joint-by-event (event open-or-close)
-  (print event)
   (let* ((joint-name (cpoe:environment-event-joint-name event))
          (object (cpoe:environment-event-object event))
          (distance (cpoe:environment-event-distance event))
@@ -174,7 +173,6 @@ If there is no other method with 1 as qualifier, this method will be executed al
      object)))
 
 (defmethod cram-occasions-events:on-event open-container ((event cpoe:container-opening-event))
-  (print event)
   (move-joint-by-event event :open)
   (unless cram-projection:*projection-environment*
     (publish-environment-joint-state (btr:joint-states (cpoe:environment-event-object event)))))

--- a/cram_3d_world/cram_urdf_environment_manipulation/src/environment.lisp
+++ b/cram_3d_world/cram_urdf_environment_manipulation/src/environment.lisp
@@ -234,8 +234,8 @@ Using a default (1 0 0)."
   (let ((joint (get-connecting-joint
                 (get-container-link container-name
                                     btr-environment))))
-    (let ((upper-limit (- (cl-urdf:upper (cl-urdf:limits joint)) 0.001))
-          (lower-limit (+ (cl-urdf:lower (cl-urdf:limits joint)) 0.001))
+    (let ((upper-limit (cl-urdf:upper (cl-urdf:limits joint)))
+          (lower-limit (cl-urdf:lower (cl-urdf:limits joint)))
           (state (btr:joint-state
                   (btr:object btr:*current-bullet-world*
                               btr-environment)

--- a/cram_3d_world/cram_urdf_environment_manipulation/src/trajectories.lisp
+++ b/cram_3d_world/cram_urdf_environment_manipulation/src/trajectories.lisp
@@ -149,14 +149,15 @@ container with revolute joints."
              grasp-pose :x-offset *drawer-handle-pregrasp-x-offset*))
       (list grasp-pose)
       traj-poses
-      (list (cram-tf:apply-transform
-             last-traj-pose
-             (cl-transforms-stamped:make-transform-stamped
-              (cl-transforms-stamped:child-frame-id last-traj-pose)
-              (cl-transforms-stamped:child-frame-id last-traj-pose)
-              (cl-transforms-stamped:stamp last-traj-pose)
-              (cl-transforms:make-3d-vector 0 0 -0.1)
-              (cl-transforms:make-identity-rotation))))))))
+      (when last-traj-pose
+        (list (cram-tf:apply-transform
+               last-traj-pose
+               (cl-transforms-stamped:make-transform-stamped
+                (cl-transforms-stamped:child-frame-id last-traj-pose)
+                (cl-transforms-stamped:child-frame-id last-traj-pose)
+                (cl-transforms-stamped:stamp last-traj-pose)
+                (cl-transforms:make-3d-vector 0 0 -0.1)
+                (cl-transforms:make-identity-rotation)))))))))
 
 
 (defun 3d-vector->keyparam-list (v)


### PR DESCRIPTION
Fixes the following bugs:
- Sealing action to distance 0.0 didn't work with goals. (Was closed to just 0.001 because of trying to avoid overshooting the limits.)
- Manpiulation of environment with distance being the same as the current joint-state raised an error. (No trajectory is calculated because the manipulation distance is too short. Just had to make sure there is no operation done on the nil result.)
- Rounding of angles before setting joint-state in event-handler just rounded up. That lead to problems when approaching the upper limit of joints.