### PR TITLE
Fix door costmap

### DIFF
--- a/cram_3d_world/cram_urdf_environment_manipulation/src/costmaps.lisp
+++ b/cram_3d_world/cram_urdf_environment_manipulation/src/costmaps.lisp
@@ -243,7 +243,7 @@ environment, in which it can be found, respectively."
          (manipulated-handle-pose
            (get-manipulated-pose
             (cl-urdf:name handle-link)
-            0.7
+            0.8
             btr-environment
             :relative T))
          (neutral-handle-pos-2d

--- a/cram_3d_world/cram_urdf_environment_manipulation/src/costmaps.lisp
+++ b/cram_3d_world/cram_urdf_environment_manipulation/src/costmaps.lisp
@@ -213,25 +213,7 @@ environment, in which it can be found, respectively."
          (v2
            (cl-transforms:v- man-handle-pos-2d joint-pos-2d))
          (v2-length
-           (sqrt (cl-transforms:dot-product v2 v2)))
-         ;; (handle-pose
-         ;;   (get-manipulated-pose
-         ;;    (cl-urdf:name handle-link)
-         ;;    0
-         ;;    btr-environment
-         ;;    :relative T))
-         ;; (handle-pos-2d
-         ;;   (cl-transforms:make-3d-vector
-         ;;    (cl-transforms:x
-         ;;     (cl-transforms:origin handle-pose))
-         ;;    (cl-transforms:y
-         ;;     (cl-transforms:origin handle-pose))
-         ;;    0))
-         ;; (v1
-         ;;   (cl-transforms:v- handle-pos-2d joint-pos-2d))
-         ;; (v1-length
-         ;;   (sqrt (cl-transforms:dot-product v1 v1)))
-         )
+           (sqrt (cl-transforms:dot-product v2 v2))))
 
     (lambda (x y)
       (let* ((vP (cl-transforms:v- (cl-transforms:make-3d-vector x y 0)
@@ -239,6 +221,77 @@ environment, in which it can be found, respectively."
              (vP-length (sqrt (cl-transforms:dot-product vP vP))))
         (if (and (< vP-length (+ v2-length padding))
                  T)
+            0
+            1)))))
+
+(defun make-opened-door-for-opposite-arm-cost-function (container-name
+                                                        btr-environment
+                                                        arm)
+  "Resolve the relation according to the pose of the door hinge joint and the
+handles neutral and manipulated poses. Disregard any samples in tha angle between
+the closed and half open state of the door.
+CONTAINER-NAME and BTR-ENVIRONMENT are the names of the container and the
+environment, in which it can be found, respectively."
+  (let* ((handle-link
+           (get-handle-link container-name btr-environment))
+         (neutral-handle-pose
+           (get-manipulated-pose
+            (cl-urdf:name handle-link)
+            0
+            btr-environment
+            :relative T))
+         (manipulated-handle-pose
+           (get-manipulated-pose
+            (cl-urdf:name handle-link)
+            0.7
+            btr-environment
+            :relative T))
+         (neutral-handle-pos-2d
+           (cl-transforms:make-3d-vector
+            (cl-transforms:x
+             (cl-transforms:origin neutral-handle-pose))
+            (cl-transforms:y
+             (cl-transforms:origin neutral-handle-pose))
+            0))
+         (man-handle-pos-2d
+           (cl-transforms:make-3d-vector
+            (cl-transforms:x
+             (cl-transforms:origin manipulated-handle-pose))
+            (cl-transforms:y
+             (cl-transforms:origin manipulated-handle-pose))
+            0))
+         (joint-name
+           (cl-urdf:name
+            (cl-urdf:child (get-connecting-joint handle-link))))
+         (joint-pose
+           (get-urdf-link-pose joint-name btr-environment))
+         (joint-pos-2d
+           (cl-transforms:make-3d-vector
+            (cl-transforms:x
+             (cl-transforms:origin joint-pose))
+            (cl-transforms:y
+             (cl-transforms:origin joint-pose))
+            0))
+         (v1 (cl-transforms:v- neutral-handle-pos-2d joint-pos-2d))
+         (v2 (cl-transforms:v- man-handle-pos-2d joint-pos-2d))
+         (angle-full (acos (angle-between-vectors v1 v2))))
+
+    (lambda (x y)
+      (let* ((vP (cl-transforms:v- (cl-transforms:make-3d-vector x y 0)
+                                    joint-pos-2d))
+             (angle-to-v1 (acos (angle-between-vectors v1 vP)))
+             (angle-to-v2 (acos (angle-between-vectors v2 vP)))
+             (v-PtoJ (cl-transforms:v-
+                      joint-pos-2d
+                      (cl-transforms:make-3d-vector x y 0)))
+             (v-PtoH (cl-transforms:v-
+                      neutral-handle-pos-2d
+                      (cl-transforms:make-3d-vector x y 0)))
+             (opens-from (v-which-side v-PtoJ v-PtoH)))
+        (if (and
+             (equal arm opens-from)
+             (< angle-to-v1 angle-full)
+             (< angle-to-v2 angle-full))
             0
             1)))))
 
@@ -314,6 +367,9 @@ Disregarding the orientation (using the pose2's)."
 (defmethod costmap:costmap-generator-name->score
     ((name (eql 'opened-door-cost-function))) 10)
 
+(defmethod costmap:costmap-generator-name->score
+    ((name (eql 'opened-door-for-opposite-arm-cost-function))) 10)
+
 
 (def-fact-group environment-manipulation-costmap (costmap:desig-costmap)
   (<- (costmap:desig-costmap ?designator ?costmap)
@@ -386,6 +442,10 @@ Disregarding the orientation (using the pose2's)."
      ?costmap)
 
     ;; cutting out for specific arm
+    (costmap:costmap-add-function
+     opened-door-for-opposite-arm-cost-function
+     (make-opened-door-for-opposite-arm-cost-function ?container-name ?btr-environment ?arm)
+     ?costmap)
 
     ;; orientate towards the door
     (lisp-fun get-container-link ?container-name ?btr-environment ?link)

--- a/cram_3d_world/cram_urdf_environment_manipulation/src/environment.lisp
+++ b/cram_3d_world/cram_urdf_environment_manipulation/src/environment.lisp
@@ -176,10 +176,12 @@ NAME in the environment BTR-ENVIRONMENT."
               (let* ((rotation
                        (cl-transforms:axis-angle->quaternion
                         (cl-transforms:make-3d-vector 0 0 1) ;; might be some other axis
-                        (if relative
-                            (* joint-position
-                               (cl-urdf:upper (cl-urdf:limits joint)))
-                            joint-position)))
+                        (-
+                         (if relative
+                             (* joint-position
+                                (cl-urdf:upper (cl-urdf:limits joint)))
+                             joint-position)
+                         (get-joint-position joint btr-environment))))
                      (link-transform
                        (cl-transforms:pose->transform
                         (get-urdf-link-pose link-name btr-environment)))

--- a/cram_3d_world/cram_urdf_environment_manipulation/src/math.lisp
+++ b/cram_3d_world/cram_urdf_environment_manipulation/src/math.lisp
@@ -84,3 +84,13 @@ from which the distance to the point (x,y) is minimal."
   (/ (cl-transforms:dot-product v1 v2)
      (* (cl-transforms:v-norm v1)
         (cl-transforms:v-norm v2))))
+
+(defun v-which-side (v1 v2)
+  "Return either :left or :right depending on which side of v1 v2 is."
+  (let ((v2-rot90ccw (cl-transforms:make-3d-vector
+                      (- (cl-transforms:y v2))
+                      (cl-transforms:x v2)
+                      0)))
+    (if (> (cl-transforms:dot-product v1 v2-rot90ccw) 0)
+        :right
+        :left)))


### PR DESCRIPTION
Fixes the door costmap so that it's not the same for left and right arms anymore.
The costmap now gets cut in front of the first 80% of the door's opening arc, when trying to open it with an opposing arm.
For example: The door of the fridge in the IAI kitchen opens to the right. So when trying to open it with the left arm, much of the costmap on the left side gets cut. That is to ensure, that the robot stands more to the right.
In general this should lead to robots standing in more benefical locations for opening containers with rotational joints.

PS.: This branch was forked from the cpollok-env-man-distance-revision branch to be able to use the features in there for smore smooth development. When that branch's PR is merged this PR should point to the branch it got merged into.