### PR TITLE
Fix call with specific type

### DIFF
--- a/cram_common/cram_manipulation_interfaces/cram-manipulation-interfaces-tests.asd
+++ b/cram_common/cram_manipulation_interfaces/cram-manipulation-interfaces-tests.asd
@@ -1,0 +1,43 @@
+;;;
+;;; Copyright (c) 2019, Christopher Pollok <cpollok@uni-bremen.de>
+;;; All rights reserved.
+;;;
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions are met:
+;;;
+;;;     * Redistributions of source code must retain the above copyright
+;;;       notice, this list of conditions and the following disclaimer.
+;;;     * Redistributions in binary form must reproduce the above copyright
+;;;       notice, this list of conditions and the following disclaimer in the
+;;;       documentation and/or other materials provided with the distribution.
+;;;     * Neither the name of the Institute for Artificial Intelligence/
+;;;       Universitaet Bremen nor the names of its contributors may be used to
+;;;       endorse or promote products derived from this software without
+;;;       specific prior written permission.
+;;;
+;;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+;;; LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+;;; CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+;;; SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+;;; CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+;;; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+;;; POSSIBILITY OF SUCH DAMAGE.
+
+(defsystem cram-manipulation-interfaces-tests
+  :author "Christopher Pollok"
+  :license "BSD"
+
+  :depends-on (cram-manipulation-interfaces
+               lisp-unit
+               cram-prolog
+               )
+  :components ((:module "tests"
+                :components
+                ((:file "package")
+                 (:file "object-hierarchy-tests" :depends-on ("package")))))
+  :perform (test-op (operation component)
+                    (symbol-call :lisp-unit '#:run-tests :all :cram-manipulation-interfaces-tests)))

--- a/cram_common/cram_manipulation_interfaces/src/utils.lisp
+++ b/cram_common/cram_manipulation_interfaces/src/utils.lisp
@@ -50,17 +50,19 @@ Example usage: (man-int:reasoning-engine-for-method #'man-int:get-action-grasps)
   (error "Sorry, MAN-INT:REASONING-ENGINE-FOR-METHOD is only supported under SBCL..."))
 
 (defun call-with-specific-type (fun object-type &rest args)
-  "Call generic function FUN with the most specific type for OBJECT-TYPE. Have
-to provide all arguments for fun after object-type in the correct order."
+  "Call generic function `fun' with the most specific type for `object-type'. Have
+to provide all arguments for `fun' after `object-type' in the correct order."
   (let ((specific-type
-            (find-most-specific-object-type-for-generic
-             fun object-type)))
-      (if specific-type
-          ;; (get-object-type-to-gripper-transform specific-type object-name arm grasp)
-          (apply (alexandria:curry fun specific-type) args)
-          (error "There is no applicable method for the generic function ~%~a~%~
+          (apply
+           #'find-most-specific-object-type-for-generic
+           fun
+           object-type
+           args)))
+    (if specific-type
+        (apply (alexandria:curry fun specific-type) args)
+        (error "There is no applicable method for the generic function ~%~a~%~
                   with object-type ~a.~%To fix this either: ~
                   ~%- Add a method with (object-type (eql ~a)) as the first specializer or ~
                   ~%- Add ~a into the type hierarchy in the cram_object_knowledge package."
-                 fun
-                 object-type object-type object-type))))
+               fun
+               object-type object-type object-type))))

--- a/cram_common/cram_manipulation_interfaces/tests/object-hierarchy-tests.lisp
+++ b/cram_common/cram_manipulation_interfaces/tests/object-hierarchy-tests.lisp
@@ -1,0 +1,90 @@
+;;;
+;;; Copyright (c) 2019, Christopher Pollok <cpollok@uni-bremen.de>
+;;; All rights reserved.
+;;;
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions are met:
+;;;
+;;;     * Redistributions of source code must retain the above copyright
+;;;       notice, this list of conditions and the following disclaimer.
+;;;     * Redistributions in binary form must reproduce the above copyright
+;;;       notice, this list of conditions and the following disclaimer in the
+;;;       documentation and/or other materials provided with the distribution.
+;;;     * Neither the name of the Institute for Artificial Intelligence/
+;;;       Universitaet Bremen nor the names of its contributors may be used to
+;;;       endorse or promote products derived from this software without
+;;;       specific prior written permission.
+;;;
+;;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+;;; LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+;;; CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+;;; SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+;;; CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+;;; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+;;; POSSIBILITY OF SUCH DAMAGE.
+
+(in-package :man-int-tests)
+
+(def-fact-group test-hierarchy (man-int:object-type-direct-subtype)
+  (<- (man-int:object-type-direct-subtype :thing :specific-thing))
+  (<- (man-int:object-type-direct-subtype :specific-thing :very-specific-thing))
+  (<- (man-int:object-type-direct-subtype :thing :other-thing)))
+
+(define-test find-most-specific-object-type-for-generic-same-type
+  (defgeneric generic (object-type a)
+    (:method ((object-type (eql :specific-thing)) a) nil))
+  (assert-eql
+   :specific-thing
+   (man-int::find-most-specific-object-type-for-generic #'generic :specific-thing 1))
+  (assert-nil
+   (man-int::find-most-specific-object-type-for-generic #'generic :unrelated-thing 1))
+  (fmakunbound 'generic))
+
+(define-test find-most-specific-object-type-for-generic-parent-type
+  (defgeneric generic (object-type a))
+  (defmethod generic ((object-type (eql :thing)) a) nil)
+  (assert-eql
+   :thing
+   (man-int::find-most-specific-object-type-for-generic #'generic :specific-thing 1))
+  (assert-eql
+   :thing
+   (man-int::find-most-specific-object-type-for-generic #'generic :very-specific-thing 1))
+  (defmethod generic ((object-type (eql :specific-thing)) a) nil)
+  (assert-eql
+   :specific-thing
+   (man-int::find-most-specific-object-type-for-generic #'generic :specific-thing 1))
+  (fmakunbound 'generic))
+
+(define-test find-most-specific-object-type-for-generic-different-heritage
+  (defgeneric generic (object-type a)
+    (:method ((object-type (eql :thing)) a) nil)
+    (:method ((object-type (eql :specific-thing)) a) nil))
+  (assert-eql
+   :specific-thing
+   (man-int::find-most-specific-object-type-for-generic #'generic :specific-thing 1))
+  (assert-eql
+   :thing
+   (man-int::find-most-specific-object-type-for-generic #'generic :other-thing 1))
+  (fmakunbound 'generic))
+
+(define-test find-most-specific-object-type-for-generic-no-additional-args
+  (defgeneric generic (object-type)
+    (:method ((object-type (eql :thing))) nil))
+  (assert-eql
+   :thing
+   (man-int::find-most-specific-object-type-for-generic #'generic :thing))
+  (fmakunbound 'generic))
+
+(define-test find-most-specific-object-type-for-generic-specific-additional-args
+  (defgeneric generic (object-type a)
+    (:method ((object-type (eql :thing)) (a (eql 1))) nil))
+  (assert-eql
+   :thing
+   (man-int::find-most-specific-object-type-for-generic #'generic :thing 1))
+  (assert-nil
+   (man-int::find-most-specific-object-type-for-generic #'generic :thing 2))
+  (fmakunbound 'generic))

--- a/cram_common/cram_manipulation_interfaces/tests/package.lisp
+++ b/cram_common/cram_manipulation_interfaces/tests/package.lisp
@@ -1,0 +1,31 @@
+;;; Copyright (c) 2019, Christopher Pollok <cpollok@uni-bremen.de>
+;;; All rights reserved.
+;;;
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions are met:
+;;;
+;;;     * Redistributions of source code must retain the above copyright
+;;;       notice, this list of conditions and the following disclaimer.
+;;;     * Redistributions in binary form must reproduce the above copyright
+;;;       notice, this list of conditions and the following disclaimer in the
+;;;       documentation and/or other materials provided with the distribution.
+;;;     * Neither the name of the Institute for Artificial Intelligence/
+;;;       Universitaet Bremen nor the names of its contributors may be used to
+;;;       endorse or promote products derived from this software without
+;;;       specific prior written permission.
+;;;
+;;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+;;; LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+;;; CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+;;; SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+;;; CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+;;; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+;;; POSSIBILITY OF SUCH DAMAGE.
+
+(defpackage :cram-manipulation-interfaces-tests
+  (:nicknames :man-int-tests)
+  (:use :common-lisp :lisp-unit :cram-prolog))


### PR DESCRIPTION
Fixes call-with-specific-type, which landed in an endless recursion if there was a method with a matching type, but non-matching specializers.
So now the function checks not only if there is a method with a matching type, but also if the methods specializers allow it to be executed with the given parameters of the call.

Essentially it's a convenient wrapper around compute-applicable-methods to check if there is a applicable method for our use case.

Also there are some tests added for the internal find-most-specific-object-type-for-generic function, which is the most important part of this.