### PR TITLE
Automatically infer object likely locations and destinations

### DIFF
--- a/cram_3d_world/cram_fetch_deliver_plans/src/fetch-and-deliver-designators.lisp
+++ b/cram_3d_world/cram_fetch_deliver_plans/src/fetch-and-deliver-designators.lisp
@@ -199,12 +199,22 @@ the `look-pose-stamped'."
     ;; arm
     (once (or (spec:property ?action-designator (:arm ?arm))
               (equal ?arm NIL)))
+    ;; context
+    (once (or (spec:property ?action-designator (:context ?context))
+              (equal ?context NIL)))
     ;; target
-    (spec:property ?action-designator (:target ?some-location-designator))
-    (desig:current-designator ?some-location-designator ?location-designator)
+    (-> (and (desig:desig-prop ?action-designator (:target ?some-location-designator))
+             (not (equal ?some-location-designator NIL)))
+        (desig:current-designator ?some-location-designator ?location-designator)
+        (and (spec:property ?object-designator (:type ?type))
+             (-> (equal ?context NIL)
+                 (lisp-fun man-int:get-object-likely-destination :kitchen :thomas :table-setting ?type ?location-designator)
+                 (lisp-fun man-int:get-object-likely-destination :kitchen :Thomas ?context ?type ?location-designator))))
     ;; robot-location
     (once (or (and (spec:property ?action-designator (:robot-location ?some-robot-loc-desig))
                    (desig:current-designator ?some-robot-loc-desig ?robot-location-designator))
+                   ;; (spec:property ?robot-location-designator (:location ?some-loc-desig-in-rob-loc-desig))
+                   ;;  (not (equal ?some-loc-desig-in-rob-loc-desig NIL)))
               (desig:designator :location ((:reachable-for ?robot)
                                            (:location ?location-designator))
                                 ?robot-location-designator)))
@@ -227,9 +237,23 @@ the `look-pose-stamped'."
     ;; object
     (spec:property ?action-designator (:object ?some-object-designator))
     (desig:current-designator ?some-object-designator ?object-designator)
+    ;; context
+    (once (or (spec:property ?action-designator (:context ?context))
+              (equal ?context NIL)))
     ;; search location
-    (spec:property ?action-designator (:location ?some-search-loc-desig))
-    (desig:current-designator ?some-search-loc-desig ?search-location-designator)
+    (-> (and (desig:desig-prop ?action-designator
+                               (:location ?some-search-loc-desig))
+             (not (equal ?some-search-loc-desig NIL)))
+        (desig:current-designator ?some-search-loc-desig
+                                  ?search-location-designator)
+        (or 
+         (and (equal ?context nil)
+              (spec:property ?object-designator (:type ?type))
+              (lisp-fun man-int:get-object-likely-location :kitchen
+                        :thomas :table-setting ?type ?search-location-designator))
+         (and (spec:property ?object-designator (:type ?type))
+              (lisp-fun man-int:get-object-likely-location :kitchen :thomas
+                        ?context ?type ?search-location-designator))))
     (-> (desig:desig-prop ?search-location-designator (:in ?_))
         (equal ?fetching-location-accessible NIL)
         (equal ?fetching-location-accessible T))
@@ -260,11 +284,14 @@ the `look-pose-stamped'."
                  (true)
                  (equal ?grasps NIL))))
     ;; target location
-    (spec:property ?action-designator
-                   (:target ?some-delivering-location-designator))
-    (desig:current-designator ?some-delivering-location-designator
-                              ?delivering-location-designator)
-    (-> (desig:desig-prop ?delivering-location-designator (:in ?_))
+    (-> (spec:property ?action-designator
+                       (:target ?some-delivering-location-designator))
+        (desig:current-designator ?some-delivering-location-designator
+                                  ?delivering-location-designator)
+        (equal ?delivering-location-designator NIL))
+    (-> (and
+         (not (equal ?delivering-location-designator NIL))
+         (desig:desig-prop ?delivering-location-designator (:in ?_)))
         (equal ?delivering-location-accessible NIL)
         (equal ?delivering-location-accessible T))
     ;; deliver location robot base
@@ -276,6 +303,7 @@ the `look-pose-stamped'."
     ;; resulting action desig
     (desig:designator :action ((:type :transporting)
                                (:object ?object-designator)
+                               (:context ?context)
                                (:search-location ?search-location-designator)
                                (:search-robot-location ?search-robot-location-designator)
                                (:fetch-robot-location ?fetch-robot-location-designator)

--- a/cram_3d_world/cram_fetch_deliver_plans/src/fetch-and-deliver-designators.lisp
+++ b/cram_3d_world/cram_fetch_deliver_plans/src/fetch-and-deliver-designators.lisp
@@ -203,6 +203,9 @@ the `look-pose-stamped'."
     (once (or (spec:property ?action-designator (:context ?context))
               (equal ?context NIL)))
     ;; target
+    ;; If the location-desig with keyword :target is not nil, get the
+    ;; current desig of it, else call man-int:get-object-likely-destination
+    ;; to infer the location desig.
     (-> (and (desig:desig-prop ?action-designator (:target ?some-location-designator))
              (not (equal ?some-location-designator NIL)))
         (desig:current-designator ?some-location-designator ?location-designator)
@@ -213,8 +216,6 @@ the `look-pose-stamped'."
     ;; robot-location
     (once (or (and (spec:property ?action-designator (:robot-location ?some-robot-loc-desig))
                    (desig:current-designator ?some-robot-loc-desig ?robot-location-designator))
-                   ;; (spec:property ?robot-location-designator (:location ?some-loc-desig-in-rob-loc-desig))
-                   ;;  (not (equal ?some-loc-desig-in-rob-loc-desig NIL)))
               (desig:designator :location ((:reachable-for ?robot)
                                            (:location ?location-designator))
                                 ?robot-location-designator)))
@@ -241,6 +242,9 @@ the `look-pose-stamped'."
     (once (or (spec:property ?action-designator (:context ?context))
               (equal ?context NIL)))
     ;; search location
+    ;; If location designator with keyword :location was given, get
+    ;; the current desig, else call man-int:get-object-likely-location 
+    ;; with given object-type and maybe context to get a location desig
     (-> (and (desig:desig-prop ?action-designator
                                (:location ?some-search-loc-desig))
              (not (equal ?some-search-loc-desig NIL)))

--- a/cram_3d_world/cram_fetch_deliver_plans/src/fetch-and-deliver-plans.lisp
+++ b/cram_3d_world/cram_fetch_deliver_plans/src/fetch-and-deliver-plans.lisp
@@ -551,6 +551,7 @@ If a failure happens, try a different `?target-location' or `?target-robot-locat
 
 (defun transport (&key
                     ((:object ?object-designator))
+                    ((:context ?context))
                     ((:search-location ?search-location))
                     ((:search-robot-location ?search-base-location))
                     ((:fetch-robot-location ?fetch-robot-location))
@@ -576,25 +577,27 @@ If a failure happens, try a different `?target-location' or `?target-robot-locat
                                       (location ?search-location)
                                       (desig:when ?search-base-location
                                         (robot-location ?search-base-location)))))
-             (?robot-name
-               (cut:var-value '?robot-name
-                              (car (prolog:prolog '(rob-int:robot ?robot-name))))))
+             ;; (?robot-name
+             ;;   (cut:var-value '?robot-name
+             ;;                  (car (prolog:prolog '(rob-int:robot
+             ;;                                        ?robot-name)))))
+             )
          (roslisp:ros-info (pp-plans transport)
                            "Found object of type ~a."
                            (desig:desig-prop-value ?perceived-object-designator :type))
 
-         (unless ?fetch-robot-location
-           (setf ?fetch-robot-location
-                 (desig:a location
-                          (reachable-for ?robot-name)
-                          (desig:when ?arm
-                            (arm ?arm))
-                          (object ?perceived-object-designator))))
-         (unless ?deliver-robot-location
-           (setf ?deliver-robot-location
-                 (desig:a location
-                          (reachable-for ?robot-name)
-                          (location ?delivering-location))))
+         ;; (unless ?fetch-robot-location
+         ;;   (setf ?fetch-robot-location
+         ;;         (desig:a location
+         ;;                  (reachable-for ?robot-name)
+         ;;                  (desig:when ?arm
+         ;;                    (arm ?arm))
+         ;;                  (object ?perceived-object-designator))))
+         ;; (unless ?deliver-robot-location
+         ;;   (setf ?deliver-robot-location
+         ;;         (desig:a location
+         ;;                  (reachable-for ?robot-name)
+         ;;                  (location ?delivering-location))))
 
          ;; If running on the real robot, execute below task tree in projection
          ;; N times first, then pick the best parameterization
@@ -619,7 +622,8 @@ If a failure happens, try a different `?target-location' or `?target-robot-locat
                                             (desig:when ?grasps
                                               (grasps ?grasps))
                                             (object ?perceived-object-designator)
-                                            (robot-location ?fetch-robot-location)
+                                            (desig:when ?fetch-robot-location
+                                                (robot-location ?fetch-robot-location))
                                             (pick-up-action ?fetch-pick-up-action)))))
                (roslisp:ros-info (pp-plans transport) "Fetched the object.")
 
@@ -639,8 +643,10 @@ If a failure happens, try a different `?target-location' or `?target-robot-locat
                                              (desig:when ?arm
                                                (arm ?arm))
                                              (object ?fetched-object)
+                                             (context ?context)
                                              (target ?delivering-location)
-                                             (robot-location ?deliver-robot-location)
+                                             (desig:when ?deliver-robot-location
+                                               (robot-location ?deliver-robot-location))
                                              (place-action ?deliver-place-action)))
                    (unless delivery-location-accessible
                      (exe:perform (desig:an action

--- a/cram_common/cram_designator_specification/src/specs.lisp
+++ b/cram_common/cram_designator_specification/src/specs.lisp
@@ -111,7 +111,7 @@
   (<- (%property ?designator (?keyword-or-list-key ?value))
     (lisp-pred typep ?designator desig:action-designator)
     (member ?keyword-or-list-key (:gripper :arm :direction :grasp :camera :type
-                                  :link :configuration
+                                  :context :link :configuration
                                   :left-configuration :right-configuration))
     (property-member (?keyword-or-list-key ?value) ?designator)
     (assert-type ?value (or keyword list) "ACTION SPEC:PROPERTY"))

--- a/cram_common/cram_manipulation_interfaces/src/manipulation-interfaces.lisp
+++ b/cram_common/cram_manipulation_interfaces/src/manipulation-interfaces.lisp
@@ -59,6 +59,24 @@ according to the reasoning engine, correspond to the given `location-designator'
   (:method :heuristics 20 (location-designator)
     (desig:resolve-location-designator-through-generators-and-validators location-designator)))
 
+(defgeneric get-object-likely-location (kitchen-name human-name context object-type)
+  (:method-combination cut:first-in-order-and-around)
+  (:documentation "Returns a matrix of doubles representing the
+storage places of objects with given type `object-type' that,
+according to the collected VR data, correspond to the given
+`kitchen-name' representing the name of the kitchen as a string,
+`human-name' representing the name of the human as a string and
+`context' representing the name of the context as a string."))
+
+(defgeneric get-object-likely-destination (kitchen-name human-name context object-type)
+  (:method-combination cut:first-in-order-and-around)
+  (:documentation "Returns a matrix of doubles representing the
+storage places of objects with given type `object-type' that,
+according to the collected VR data, correspond to the given
+`kitchen-name' representing the name of the kitchen as a string,
+`human-name' representing the name of the human as a string and
+`context' representing the name of the context as a string."))
+
 (defmethod desig:resolve-designator :around ((desig desig:location-designator) role)
   "We have to hijack DESIG:RESOLVE-DESIGNATOR because otherwise we would have to
 make CRAM_DESIGNATORS package depend on CRAM_MANIPULATION_INTERFACES,

--- a/cram_common/cram_manipulation_interfaces/src/manipulation-interfaces.lisp
+++ b/cram_common/cram_manipulation_interfaces/src/manipulation-interfaces.lisp
@@ -61,21 +61,19 @@ according to the reasoning engine, correspond to the given `location-designator'
 
 (defgeneric get-object-likely-location (kitchen-name human-name context object-type)
   (:method-combination cut:first-in-order-and-around)
-  (:documentation "Returns a matrix of doubles representing the
-storage places of objects with given type `object-type' that,
-according to the collected VR data, correspond to the given
-`kitchen-name' representing the name of the kitchen as a string,
-`human-name' representing the name of the human as a string and
-`context' representing the name of the context as a string."))
+  (:documentation "Returns a location designator representing the
+storage places of objects with given type `object-type' corresponding
+to the given `kitchen-name' representing the name of the kitchen as a
+string, `human-name' representing the name of the human as a string
+and `context' representing the name of the context as a string."))
 
 (defgeneric get-object-likely-destination (kitchen-name human-name context object-type)
   (:method-combination cut:first-in-order-and-around)
-  (:documentation "Returns a matrix of doubles representing the
-storage places of objects with given type `object-type' that,
-according to the collected VR data, correspond to the given
-`kitchen-name' representing the name of the kitchen as a string,
-`human-name' representing the name of the human as a string and
-`context' representing the name of the context as a string."))
+  (:documentation "Returns a location designator representing the
+destination places of objects with given type `object-type' corresponding
+to the given `kitchen-name' representing the name of the kitchen as a
+string, `human-name' representing the name of the human as a string
+and `context' representing the name of the context as a string."))
 
 (defmethod desig:resolve-designator :around ((desig desig:location-designator) role)
   "We have to hijack DESIG:RESOLVE-DESIGNATOR because otherwise we would have to

--- a/cram_common/cram_manipulation_interfaces/src/package.lisp
+++ b/cram_common/cram_manipulation_interfaces/src/package.lisp
@@ -51,6 +51,8 @@
    #:get-action-trajectory
    #:get-action-grasps
    #:get-location-poses
+   #:get-object-likely-location
+   #:get-object-likely-destination
    #:get-container-opening-distance
    #:get-container-closing-distance
    ;; grasps

--- a/cram_common/cram_object_knowledge/src/household.lisp
+++ b/cram_common/cram_object_knowledge/src/household.lisp
@@ -325,3 +325,440 @@
   :2nd-pregrasp-offsets `(0.0 0.0 ,*bowl-pregrasp-z-offset*)
   :lift-offsets `(0.0 0.0 ,*bowl-pregrasp-z-offset*)
   :2nd-lift-offsets `(0.0 0.0 ,*bowl-pregrasp-z-offset*))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;; location ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defmethod man-int:get-object-likely-location :heuristics 20
+    ((?kitchen-name (eql :kitchen))
+     ?human-name 
+     (?context (eql :table-setting))
+     (?object-type (eql :bowl)))
+
+  (desig:a location
+           (on (desig:an object
+                         (type counter-top)
+                         (urdf-name sink-area-surface)
+                         (owl-name "kitchen_sink_block_counter_top")
+                         (part-of ?kitchen-name)))
+           (side left)
+           (side front)
+           (range-invert 0.5)))
+
+(defmethod man-int:get-object-likely-location :heuristics 20
+    ((?kitchen-name (eql :kitchen))
+     ?human-name 
+     (?context (eql :table-setting))
+     (?object-type (eql :spoon)))
+  
+  (desig:a location
+           (in (desig:an object
+                         (type drawer)
+                         (urdf-name sink-area-left-upper-drawer-main)
+                         (owl-name "drawer_sinkblock_upper_open")
+                         (part-of ?kitchen-name)))
+           (side front)))
+
+(defmethod man-int:get-object-likely-location :heuristics 20
+    ((?kitchen-name (eql :kitchen))
+     ?human-name 
+     (?context (eql :table-setting))
+     (?object-type (eql :knife)))
+  
+  (desig:a location
+           (in (desig:an object
+                         (type drawer)
+                         (urdf-name sink-area-left-upper-drawer-main)
+                         (owl-name "drawer_sinkblock_upper_open")
+                         (part-of ?kitchen-name)))
+           (side front)))
+
+(defmethod man-int:get-object-likely-location :heuristics 20
+    ((?kitchen-name (eql :kitchen))
+     ?human-name 
+     (?context (eql :table-setting))
+     (?object-type (eql :plate)))
+
+  (desig:a location
+           (on (desig:an object
+                         (type counter-top)
+                         (urdf-name sink-area-surface)
+                         (owl-name "kitchen_sink_block_counter_top")
+                         (part-of ?kitchen-name)))
+           (side left)
+           (side front)
+           (range-invert 0.5)))
+
+(defmethod man-int:get-object-likely-location :heuristics 20
+    ((?kitchen-name (eql :kitchen))
+     ?human-name 
+     (?context (eql :table-setting))
+     (?object-type (eql :mug)))
+
+  (desig:a location
+           (side left)
+           (on (desig:an object
+                         (type counter-top)
+                         (urdf-name sink-area-surface)
+                         (owl-name "kitchen_sink_block_counter_top")
+                         (part-of ?kitchen-name)))))
+
+(defmethod man-int:get-object-likely-location :heuristics 20
+    ((?kitchen-name (eql :kitchen))
+     ?human-name 
+     (?context (eql :table-setting))
+     (?object-type (eql :cup)))
+  
+  (desig:a location
+           (side left)
+           (on (desig:an object
+                         (type counter-top)
+                         (urdf-name sink-area-surface)
+                         (owl-name "kitchen_sink_block_counter_top")
+                         (part-of ?kitchen-name)))))
+
+(defmethod man-int:get-object-likely-location :heuristics 20
+    ((?kitchen-name (eql :kitchen))
+     ?human-name 
+     (?context (eql :table-setting))
+     (?object-type (eql :breakfast-cereal)))
+
+  (desig:a location
+           (on (desig:an object
+                         (type counter-top)
+                         (urdf-name sink-area-surface)
+                         (owl-name "kitchen_sink_block_counter_top")
+                         (part-of ?kitchen-name)))
+           (side left)
+           (side front)
+           (range 0.5)))
+
+(defmethod man-int:get-object-likely-location :heuristics 20
+    ((?kitchen-name (eql :kitchen))
+     ?human-name 
+     (?context (eql :table-setting))
+     (?object-type (eql :milk)))
+
+  (desig:a location
+           (side left)
+           (side front)
+           (range 0.5)
+           (on;; in
+            (desig:an object
+                      (type counter-top)
+                      (urdf-name sink-area-surface ;; iai-fridge-main
+                                 )
+                      (owl-name "kitchen_sink_block_counter_top"
+                                ;; "drawer_fridge_upper_interior"
+                                )
+                      (part-of ?kitchen-name)))))
+
+(defmethod man-int:get-object-likely-location :heuristics 20
+    ((?kitchen-name (eql :kitchen))
+     ?human-name 
+     (?context (eql :table-setting))
+     (?object-type (eql :bottle)))
+
+  (desig:a location
+           (side left)
+           (side front)
+           (range 0.5)
+           (on;; in
+            (desig:an object
+                      (type counter-top)
+                      (urdf-name sink-area-surface ;; iai-fridge-main
+                                 )
+                      (owl-name "kitchen_sink_block_counter_top"
+                                ;; "drawer_fridge_upper_interior"
+                                )
+                      (part-of ?kitchen-name)))))
+
+;;;;;;;;;;;;;;;;;;;;;;;; destination ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;; bowl ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defmethod man-int:get-object-likely-destination :heuristics 20
+    ((?kitchen-name (eql :kitchen))
+     ?human-name 
+     (?context (eql :table-setting))
+     (?object-type (eql :bowl)))
+
+  (desig:a location
+           (on (desig:an object
+                         (type counter-top)
+                         (urdf-name kitchen-island-surface)
+                         (owl-name "kitchen_island_counter_top")
+                         (part-of ?kitchen-name)))
+           (for (desig:an object (type ?object-type))) ;; 'for' keyword
+           ;; instead 'object' since we want that the bowl should be
+           ;; placed on surface of the kitchen island
+           (context ?context)
+           (object-count 3)
+           (side back)
+           (side right)
+           (range-invert 0.5)))
+
+(defmethod man-int:get-object-likely-destination :heuristics 20
+    ((?kitchen-name (eql :kitchen))
+     ?human-name 
+     (?context (eql :table-cleaning))
+     (?object-type (eql :bowl)))
+
+  (desig:a location
+           (on (desig:an object
+                         (type area-sink)
+                         (urdf-name sink-area-sink)
+                         (owl-name "kitchen_sink_area_sink")
+                         (part-of ?kitchen-name)))
+           (for (desig:an object (type ?object-type)))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;; spoon ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defmethod man-int:get-object-likely-destination :heuristics 20 
+    ((?kitchen-name (eql :kitchen))
+     ?human-name 
+     (?context (eql :table-setting)) 
+     (?object-type (eql :spoon)))
+
+  (let ((?other-object :bowl))
+    (desig:a location
+             (right-of (desig:an object (type ?other-object)))
+             (near (desig:an object (type ?other-object)))
+             (for (desig:an object (type ?object-type)))
+             (orientation support-aligned))))
+
+(defmethod man-int:get-object-likely-destination :heuristics 20
+    ((?kitchen-name (eql :kitchen))
+     ?human-name 
+     (?context (eql :table-cleaning))
+     (?object-type (eql :spoon)))
+
+  (desig:a location
+           (on (desig:an object
+                         (type area-sink)
+                         (urdf-name sink-area-sink)
+                         (owl-name "kitchen_sink_area_sink")
+                         (part-of ?kitchen-name)))
+           (for (desig:an object (type ?object-type)))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;; knife ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defmethod man-int:get-object-likely-destination :heuristics 20 
+    ((?kitchen-name (eql :kitchen))
+     ?human-name 
+     (?context (eql :table-setting))
+     (?object-type (eql :knife)))
+  
+  (desig:a location
+           (on (desig:an object
+                         (type counter-top)
+                         (urdf-name kitchen-island-surface)
+                         (owl-name "kitchen_island_counter_top")
+                         (part-of ?kitchen-name)))
+           (for (desig:an object (type ?object-type)))))
+
+(defmethod man-int:get-object-likely-destination :heuristics 20
+    ((?kitchen-name (eql :kitchen))
+     ?human-name 
+     (?context (eql :table-cleaning))
+     (?object-type (eql :knife)))
+
+  (desig:a location
+           (on (desig:an object
+                         (type area-sink)
+                         (urdf-name sink-area-sink)
+                         (owl-name "kitchen_sink_area_sink")
+                         (part-of ?kitchen-name)))
+           (for (desig:an object (type ?object-type)))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;; plate ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defmethod man-int:get-object-likely-destination :heuristics 20 
+    ((?kitchen-name (eql :kitchen))
+     ?human-name 
+     (?context (eql :table-setting))
+     (?object-type (eql :plate)))
+
+  (desig:a location
+           (on (desig:an object
+                         (type counter-top)
+                         (urdf-name kitchen-island-surface)
+                         (owl-name "kitchen_island_counter_top")
+                         (part-of ?kitchen-name)))
+           (for (desig:an object (type ?object-type)))))
+
+(defmethod man-int:get-object-likely-destination :heuristics 20
+    ((?kitchen-name (eql :kitchen))
+     ?human-name 
+     (?context (eql :table-cleaning))
+     (?object-type (eql :plate)))
+
+  (desig:a location
+           (on (desig:an object
+                         (type area-sink)
+                         (urdf-name sink-area-sink)
+                         (owl-name "kitchen_sink_area_sink")
+                         (part-of ?kitchen-name)))
+           (for (desig:an object (type ?object-type)))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;; mug ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defmethod man-int:get-object-likely-destination :heuristics 20 
+    ((?kitchen-name (eql :kitchen))
+     ?human-name 
+     (?context (eql :table-setting)) 
+     (?object-type (eql :mug)))
+
+  (desig:a location
+           (on (desig:an object
+                         (type counter-top)
+                         (urdf-name kitchen-island-surface)
+                         (owl-name "kitchen_island_counter_top")
+                         (part-of ?kitchen-name)))
+           (for (desig:an object (type ?object-type)))))
+
+
+(defmethod man-int:get-object-likely-destination :heuristics 20
+    ((?kitchen-name (eql :kitchen))
+     ?human-name 
+     (?context (eql :table-cleaning))
+     (?object-type (eql :mug)))
+
+  (desig:a location
+           (on (desig:an object
+                         (type area-sink)
+                         (urdf-name sink-area-sink)
+                         (owl-name "kitchen_sink_area_sink")
+                         (part-of ?kitchen-name)))
+           (for (desig:an object (type ?object-type)))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;; cup ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defmethod man-int:get-object-likely-destination :heuristics 20 
+    ((?kitchen-name (eql :kitchen))
+     ?human-name 
+     (?context (eql :table-setting))
+     (?object-type (eql :cup)))
+
+  (let ((?other-object :bowl))
+    (desig:a location
+             (right-of (desig:an object (type ?other-object)))
+             (behind (desig:an object (type ?other-object)))
+             (near (desig:an object (type ?other-object)))
+             (for (desig:an object (type ?object-type))))))
+
+(defmethod man-int:get-object-likely-destination :heuristics 20
+    ((?kitchen-name (eql :kitchen))
+     ?human-name 
+     (?context (eql :table-cleaning))
+     (?object-type (eql :cup)))
+
+  (desig:a location
+           (on (desig:an object
+                         (type area-sink)
+                         (urdf-name sink-area-sink)
+                         (owl-name "kitchen_sink_area_sink")
+                         (part-of ?kitchen-name)))
+           (for (desig:an object (type ?object-type)))))
+
+;;;;;;;;;;;;;;;;;;;;;;; breakfast-cereal ;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defmethod man-int:get-object-likely-destination :heuristics 20 
+    ((?kitchen-name (eql :kitchen))
+     ?human-name 
+     (?context (eql :table-setting)) 
+     (?object-type (eql :breakfast-cereal)))
+
+  (let ((?pose
+          (cl-transforms-stamped:make-pose-stamped
+           "map"
+           0.0
+           (cl-transforms:make-3d-vector -0.78 0.8 0.95)
+           (cl-transforms:make-quaternion 0 0 0.6 0.4)))
+        ;; (?other-object :bowl)
+        )
+    (desig:a location
+             (pose ?pose)
+             ;; (left-of (desig:an object (type ?other-object)))
+             ;; (far-from (desig:an object (type ?other-object)))
+             ;; (for (desig:an object (type ?object-type)))
+             ;; (on (desig:an object
+             ;;               (type counter-top)
+             ;;               (urdf-name kitchen-island-surface)
+             ;;               (owl-name "kitchen_island_counter_top")
+             ;;               (part-of ?kitchen-name)))
+             ;; (side back)
+             )))
+
+(defmethod man-int:get-object-likely-destination :heuristics 20
+    ((?kitchen-name (eql :kitchen))
+     ?human-name 
+     (?context (eql :table-cleaning))
+     (?object-type (eql :breakfast-cereal)))
+
+  (desig:a location
+           (on (desig:an object
+                         (type area-sink)
+                         (urdf-name sink-area-sink)
+                         (owl-name "kitchen_sink_area_sink")
+                         (part-of ?kitchen-name)))
+           (for (desig:an object (type ?object-type)))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;; milk ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defmethod man-int:get-object-likely-destination :heuristics 20 
+    ((?kitchen-name (eql :kitchen))
+     ?human-name 
+     (?context (eql :table-setting))
+     (?object-type (eql :milk)))
+
+  (let ((?other-object :bowl))
+    (desig:a location
+             (left-of (desig:an object (type ?other-object)))
+             (far-from (desig:an object (type ?other-object)))
+             (for (desig:an object (type ?object-type))))))
+
+(defmethod man-int:get-object-likely-destination :heuristics 20
+    ((?kitchen-name (eql :kitchen))
+     ?human-name 
+     (?context (eql :table-cleaning))
+     (?object-type (eql :milk)))
+
+  (desig:a location
+           (on (desig:an object
+                         (type area-sink)
+                         (urdf-name sink-area-sink)
+                         (owl-name "kitchen_sink_area_sink")
+                         (part-of ?kitchen-name)))
+           (for (desig:an object (type ?object-type)))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;; bottle ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defmethod man-int:get-object-likely-destination :heuristics 20 
+    ((?kitchen-name (eql :kitchen))
+     ?human-name 
+     (?context (eql :table-setting))
+     (?object-type (eql :bottle)))
+
+  (desig:a location
+           (on (desig:an object
+                         (type counter-top)
+                         (urdf-name kitchen-island-surface)
+                         (owl-name "kitchen_island_counter_top")
+                         (part-of ?kitchen-name)))
+           (for (desig:an object (type ?object-type)))))
+
+(defmethod man-int:get-object-likely-destination :heuristics 20
+    ((?kitchen-name (eql :kitchen))
+     ?human-name 
+     (?context (eql :table-cleaning))
+     (?object-type (eql :bottle)))
+
+  (desig:a location
+           (on (desig:an object
+                         (type area-sink)
+                         (urdf-name sink-area-sink)
+                         (owl-name "kitchen_sink_area_sink")
+                         (part-of ?kitchen-name)))
+           (for (desig:an object (type ?object-type)))))
+

--- a/cram_pr2/cram_pr2_pick_place_demo/src/demo.lisp
+++ b/cram_pr2/cram_pr2_pick_place_demo/src/demo.lisp
@@ -125,168 +125,65 @@
 
   (initialize)
   (when cram-projection:*projection-environment*
-    (spawn-objects-on-sink-counter :random random))
+    (if random
+        (spawn-objects-on-sink-counter-randomly)
+        (spawn-objects-on-sink-counter)))
 
   (park-robot)
 
-  (let ((object-fetching-locations
-          `((:breakfast-cereal . ,(desig:a location
-                                           (on (desig:an object
-                                                         (type counter-top)
-                                                         (urdf-name sink-area-surface)
-                                                         (owl-name "kitchen_sink_block_counter_top")
-                                                         (part-of kitchen)))
-                                           (side left)
-                                           (side front)
-                                           (range 0.5)))
-            (:cup . ,(desig:a location
-                              (side left)
-                              (on (desig:an object
-                                            (type counter-top)
-                                            (urdf-name sink-area-surface)
-                                            (owl-name "kitchen_sink_block_counter_top")
-                                            (part-of kitchen)))))
-            (:bowl . ,(desig:a location
-                               (on (desig:an object
-                                             (type counter-top)
-                                             (urdf-name sink-area-surface)
-                                             (owl-name "kitchen_sink_block_counter_top")
-                                             (part-of kitchen)))
-                               (side left)
-                               (side front)
-                               (range-invert 0.5)))
-            (:spoon . ,(desig:a location
-                                (in (desig:an object
-                                              (type drawer)
-                                              (urdf-name sink-area-left-upper-drawer-main)
-                                              (owl-name "drawer_sinkblock_upper_open")
-                                              (part-of kitchen)))
-                                (side front)))
-            (:milk . ,(desig:a location
-                               (side left)
-                               (side front)
-                               (range 0.5)
-                               (on;; in
-                                   (desig:an object
-                                             (type counter-top)
-                                             (urdf-name sink-area-surface ;; iai-fridge-main
-                                                        )
-                                             (owl-name "kitchen_sink_block_counter_top"
-                                                       ;; "drawer_fridge_upper_interior"
-                                                       )
-                                             (part-of kitchen)))))))
-        (object-placing-locations
-          (let ((?pose
-                  (cl-transforms-stamped:make-pose-stamped
-                   "map"
-                   0.0
-                   (cl-transforms:make-3d-vector -0.78 0.8 0.95)
-                   (cl-transforms:make-quaternion 0 0 0.6 0.4))))
-            `((:breakfast-cereal . ,(desig:a location
-                                             (pose ?pose)
-                                             ;; (left-of (an object (type bowl)))
-                                             ;; (far-from (an object (type bowl)))
-                                             ;; (for (an object (type breakfast-cereal)))
-                                             ;; (on (desig:an object
-                                             ;;               (type counter-top)
-                                             ;;               (urdf-name kitchen-island-surface)
-                                             ;;               (owl-name "kitchen_island_counter_top")
-                                             ;;               (part-of kitchen)))
-                                             ;; (side back)
-                                             ))
-              (:cup . ,(desig:a location
-                                (right-of (an object (type bowl)))
-                                (behind (an object (type bowl)))
-                                (near (an object (type bowl)))
-                                (for (an object (type cup)))))
-              (:bowl . ,(desig:a location
-                                 (on (desig:an object
-                                               (type counter-top)
-                                               (urdf-name kitchen-island-surface)
-                                               (owl-name "kitchen_island_counter_top")
-                                               (part-of kitchen)))
-                                 (context table-setting)
-                                 (for (an object (type bowl)))
-                                 (object-count 3)
-                                 (side back)
-                                 (side right)
-                                 (range-invert 0.5)))
-              (:spoon . ,(desig:a location
-                                  (right-of (an object (type bowl)))
-                                  (near (an object (type bowl)))
-                                  (for (an object (type spoon)))
-                                  (orientation support-aligned)))
-              (:milk . ,(desig:a location
-                                 (left-of (an object (type bowl)))
-                                 (far-from (an object (type bowl)))
-                                 (for (an object (type milk)))))))))
+  ;; (an object
+  ;;     (obj-part "drawer_sinkblock_upper_handle"))
+  
+  (dolist (?object-type list-of-objects)
+    (let* ((?arm-to-use
+             (cdr (assoc ?object-type *object-grasping-arms*)))
+           (?cad-model
+             (cdr (assoc ?object-type *object-cad-models*)))
+           (?color
+             (cdr (assoc ?object-type *object-colors*)))
+           (?object-to-fetch
+             (desig:an object
+                       (type ?object-type)
+                       (desig:when ?cad-model
+                         (cad-model ?cad-model))
+                       (desig:when ?color
+                         (color ?color)))))
 
-    ;; (an object
-    ;;     (obj-part "drawer_sinkblock_upper_handle"))
-
-    (dolist (?object-type list-of-objects)
-      (let* ((?fetching-location
-               (cdr (assoc ?object-type object-fetching-locations)))
-             (?delivering-location
-               (cdr (assoc ?object-type object-placing-locations)))
-             (?arm-to-use
-               (cdr (assoc ?object-type *object-grasping-arms*)))
-             (?cad-model
-               (cdr (assoc ?object-type *object-cad-models*)))
-             (?color
-               (cdr (assoc ?object-type *object-colors*)))
-             (?object-to-fetch
-               (desig:an object
-                         (type ?object-type)
-                         (location ?fetching-location)
-                         (desig:when ?cad-model
-                           (cad-model ?cad-model))
-                         (desig:when ?color
-                           (color ?color)))))
-
-        (when (eq ?object-type :bowl)
-          (cpl:with-failure-handling
-              ((common-fail:high-level-failure (e)
-                 (roslisp:ros-warn (pp-plans demo) "Failure happened: ~a~%Skipping the search" e)
-                 (return)))
-            (let ((?loc (cdr (assoc :breakfast-cereal object-fetching-locations))))
-              (exe:perform
-               (desig:an action
-                         (type searching)
-                         (object (desig:an object (type breakfast-cereal)))
-                         (location ?loc))))))
-
+      (when (eq ?object-type :bowl)
         (cpl:with-failure-handling
             ((common-fail:high-level-failure (e)
-               (roslisp:ros-warn (pp-plans demo) "Failure happened: ~a~%Skipping..." e)
+               (roslisp:ros-warn (pp-plans demo) "Failure happened: ~a~%Skipping the search" e)
                (return)))
-          (if (eq ?object-type :bowl)
-              (exe:perform
-               (desig:an action
-                         (type transporting)
-                         (object ?object-to-fetch)
-                         ;; (arm right)
-                         (location ?fetching-location)
-                         (target ?delivering-location)))
-              (if (eq ?object-type :breakfast-cereal)
-                  (exe:perform
-                   (desig:an action
-                             (type transporting)
-                             (object ?object-to-fetch)
-                             ;; (arm right)
-                             (location ?fetching-location)
-                             (target ?delivering-location)))
-                  (exe:perform
-                   (desig:an action
-                             (type transporting)
-                             (object ?object-to-fetch)
-                             (desig:when ?arm-to-use
-                               (arm ?arm-to-use))
-                             (location ?fetching-location)
-                             (target ?delivering-location))))))
+          (let ((?loc (man-int:get-object-likely-location
+                       :kitchen :thomas :table-setting :breakfast-cereal)))
+            (exe:perform
+             (desig:an action
+                       (type searching)
+                       (object (desig:an object (type breakfast-cereal)))
+                       (location ?loc))))))
 
-        ;; (setf proj-reasoning::*projection-reasoning-enabled* nil)
-        )))
+      (cpl:with-failure-handling
+          ((common-fail:high-level-failure (e)
+             (roslisp:ros-warn (pp-plans demo) "Failure happened: ~a~%Skipping..." e)
+             (return)))
+
+        (if (or (eq ?object-type :bowl)
+                (eq ?object-type :breakfast-cereal))
+            (exe:perform
+             (desig:an action
+                       (type transporting)
+                       (object ?object-to-fetch)
+                       ;; (arm right)
+                       ))
+            (exe:perform
+             (desig:an action
+                       (type transporting)
+                       (object ?object-to-fetch)
+                       (desig:when ?arm-to-use
+                         (arm ?arm-to-use))))))
+
+      ;; (setf proj-reasoning::*projection-reasoning-enabled* nil)
+      ))
 
   ;; (setf proj-reasoning::*projection-reasoning-enabled* nil)
 


### PR DESCRIPTION
**New Stuff**:

- Implemented functions `get-object-likely-destination/location` in `cram_manipulation_interfaces:manipulation-interfaces.lisp`
- Created `defmethods :heuristic 20` in `cram_object_knowledge:household.lisp` 
- Integrated `get-object-likely-location/destination` in `cram_fetch_deliver_plans`

**Testing**:

Since mostly location designators were moved from `cram_pr2_pick_place_demo:demo.lisp` to `cram_object_knowledge:household.lisp` through `get-object-likely-location/destination,` I reran the `demo-random` in `cram_pr2_pick_place_demo:demo.lisp.`

terminal:
`roslaunch cram_pr2_pick_place_demo sandbox.launch`

roslisp_repl:
```
(ros-load:load-system "cram_pr2_pick_place_demo" :cram-pr2-pick-place-demo)
(ros-load:load-system "cram_pr2_description" :cram-pr2-description)
(in-package :demo)
(roslisp-utilities:startup-ros)
(urdf-proj:with-simulated-robot (demo-random nil))
```