### PR TITLE
automatic object to environment/item attachment in on-event object-detached-robot

### DIFF
--- a/cram_3d_world/cram_bullet_reasoning_belief_state/src/event-handlers.lisp
+++ b/cram_3d_world/cram_bullet_reasoning_belief_state/src/event-handlers.lisp
@@ -72,22 +72,38 @@ If there is no other method with 1 as qualifier, this method will be executed al
     (when btr-object
       (btr:detach-object robot-object btr-object :link link)
       (btr:simulate btr:*current-bullet-world* 10)
-      ;; finding the link that supports the object now
+      ;; Finding the link or item that supports the object now:
+      ;; if btr-object is in contact with the environment and a item,
+      ;; the environment will be prefered.
       (flet ((get-contacting-link (obj-name)
-               (cdr (first (member obj-name
-                                   ;; get all links contacting items
-                                   ;; in the environment
-                                   (btr:link-contacts
-                                    (btr:get-environment-object))
-                                   :key (lambda (item-and-link-name-cons)
-                                          (btr:name (car item-and-link-name-cons)))
-                                   :test #'equal)))))
+               (cdr (find obj-name
+                          ;; get all links contacting items
+                          ;; in the environment
+                          (btr:link-contacts
+                           (btr:get-environment-object))
+                          :key (lambda (item-and-link-name-cons)
+                                 (btr:name (car item-and-link-name-cons)))
+                          :test #'equal)))
+             (get-contacting-item (obj-name)
+               (car (remove-if-not
+                     (lambda (c)
+                       (typep c 'btr:item))
+                     (btr:find-objects-in-contact btr:*current-bullet-world*
+                                                  (btr:object
+                                                   btr:*current-bullet-world* 
+                                                   obj-name))))))
         (let ((environment-object (btr:get-environment-object))
               (environment-link (get-contacting-link btr-object-name)))
-          ;; attaching the link to the object if it finds one.
-          (unless (cut:is-var environment-link)
-            (btr:attach-object environment-object btr-object
-                               :link environment-link)))))))
+          ;; If a link contacting btr-object was found, btr-object
+          ;; will be attached to it, else it will be tested, if
+          ;; btr-object is in contact with an item. If it is the
+          ;; btr-object will be attached loose.
+          (if environment-link
+              (btr:attach-object environment-object btr-object
+                                 :link environment-link)
+              (let ((item-object (get-contacting-item btr-object-name)))
+                (when item-object
+                  (btr:attach-object item-object btr-object :loose T)))))))))
 
 (defmethod cram-occasions-events:on-event btr-attach-two-objs ((event cpoe:object-attached-object))
   (let* ((btr-object-name (cpoe:event-object-name event))


### PR DESCRIPTION
**New Stuff:**

Since `supported-by` did not work properly I used some Lisp functions to attach the dropped items to the environment or the item it lands on.

**Testing:**

To test this somehow I wrote 2 similiar functions which take either a bowl or spoon and drop it once on the environment and once on a plate. To show that the attachment worked properly the attached-objects list of the environment will be printed and the pose of the item the spoon or bowl dropped on will be changed.

Why no unit-tests? Sometimes the spoon and bowl do not land on the plate. 

terminal:
`roslaunch cram_pr2_pick_place_demo sandbox.launch`

roslisp_repl:
```
(ros-load:load-system "cram_pr2_pick_place_demo" :cram-pr2-pick-place-demo)
(ros-load:load-system "cram_pr2_description" :cram-pr2-description)
(in-package :demo)
(roslisp-utilities:startup-ros)

```
```

(defun drop-spoon-pr2 ()
        (init-projection)
        (spawn-objects-on-sink-counter)
        (setf (btr::link-pose (btr::get-environment-object)
                            "sink_area_left_upper_drawer_main")
            (btr::make-pose
             (btr::make-3d-vector 0.95 0.9 0.754)
             (btr::make-quaternion 0.0 0.0 1.0 0)))
        (sleep 1)
        (setf (btr::pose (btr:get-robot-object))
                        (btr::make-pose
                         (btr::make-3d-vector 0.04 0.84 0.00)
                         (cl-transforms:make-quaternion 0.0 0.0
                                                        0.2431208
                                                        0.97)))
        (sleep 1)
        (cpl:with-failure-handling
               (((or CRAM-COMMON-FAILURES:MANIPULATION-POSE-UNREACHABLE) (e)
                  (setf (btr::pose (btr:get-robot-object))
                        (btr::make-pose
                         (btr::make-3d-vector 0.04 0.84 0.00)
                         (cl-transforms:make-quaternion 0.0 0.0
                                                        0.2431208
                                                        0.97)))
                  (sleep 1)
                 (cpl:retry)))
             (let* ((?type :spoon)
                    (?name :spoon-1)
                    (?search-there (btr::make-pose-stamped
                                    "map"
                                    0.0
                                    (btr::make-3d-vector 0.9 1.3 0.77)
                                    (btr::make-identity-rotation)))
                    (?more-precise-perceived-object-desig
                      (exe:perform (desig:an action
                                             (type searching)
                                             (object (desig:an object
                                                               (type ?type)
                                                               (name ?name)))
                                             (location (desig:a location 
                                                                (pose ?search-there)))))))
               
               (exe:perform (desig:an action 
                                      (type picking-up)
                                      (object ?more-precise-perceived-object-desig)
                                      (grasp :top)))))
        (let ((spoon-pos (cl-transforms:origin (btr:pose (btr:object
                                      btr:*current-bullet-world*
                                      :spoon-1)))))
          (btr-utils:spawn-object :plate-1 :plate :pose
                                      `((,(cl-transforms:x spoon-pos)
                                         ,(cl-transforms:y spoon-pos)
                                         0.74)
                                        (0 0 0 1))))
        (print "after-picking: attached-objects at the env:")
        (print (btr::attached-objects (btr::get-environment-object)))
        (sleep 5)
        (cram-occasions-events:on-event (make-instance
                                       'cpoe:object-detached-robot 
                                       :arm :right
                                       :object-name :spoon-1))
        (print "after-dropping:attached-objects at the env:")
        (print (btr::attached-objects (btr::get-environment-object)))
        (sleep 5)
        (print "objects should now fly away, since the spoon follows
                                      the plate")
        (dotimes (v 10) 
          (setf 
           (btr:pose (btr:object btr:*current-bullet-world* :plate-1))
           (btr:pose (btr:object btr:*current-bullet-world* :spoon-1)))
          (sleep 1))
        (print "objects should now stay in the air")
        (dotimes (v 10) 
          (setf 
           (btr:pose (btr:object btr:*current-bullet-world* :spoon-1))
           (btr:pose (btr:object btr:*current-bullet-world* :plate-1)))
          (sleep 1))
        (print "now lets drop spoon on the env")
(setf (btr::link-pose (btr::get-environment-object)
                            "sink_area_left_upper_drawer_main")
            (btr::make-pose
             (btr::make-3d-vector 1.52 0.9 0.754)
             (btr::make-quaternion 0.0 0.0 1.0 0)))
        (spawn-objects-on-sink-counter)
(setf (btr::link-pose (btr::get-environment-object)
                            "sink_area_left_upper_drawer_main")
            (btr::make-pose
             (btr::make-3d-vector 0.95 0.9 0.754)
             (btr::make-quaternion 0.0 0.0 1.0 0)))
        (cpl:with-failure-handling
               (((or CRAM-COMMON-FAILURES:MANIPULATION-POSE-UNREACHABLE) (e)
                 (setf (btr::pose (btr:get-robot-object))
                        (btr::make-pose
                         (btr::make-3d-vector 0.04 0.84 0.00)
                         (cl-transforms:make-quaternion 0.0 0.0
                                                        0.2431208
                                                        0.97)))
                  (sleep 1)
                 (cpl:retry)))
             (let* ((?type :spoon)
                    (?name :spoon-1)
                    (?search-there (btr::make-pose-stamped
                                    "map"
                                    0.0
                                    (btr::make-3d-vector 0.9 1.3 0.77)
                                    (btr::make-identity-rotation)))
                    (?more-precise-perceived-object-desig
                      (exe:perform (desig:an action
                                             (type searching)
                                             (object (desig:an object
                                                               (type ?type)
                                                               (name ?name)))
                                             (location (desig:a location 
                                                                (pose ?search-there)))))))
               
               (exe:perform (desig:an action 
                                      (type picking-up)
                                      (object ?more-precise-perceived-object-desig)
                                      (grasp :top)))))
        (print "after-picking: attached-objects at the env:")
        (print (btr::attached-objects (btr::get-environment-object)))
        (sleep 5)
        (cram-occasions-events:on-event (make-instance
                                       'cpoe:object-detached-robot 
                                       :arm :right
                                       :object-name :spoon-1))
        (print "after-dropping:attached-objects at the env:")
        (print (btr::attached-objects (btr::get-environment-object))))
```
```

(defun drop-bowl-pr2 ()
           (init-projection) 
           (spawn-objects-on-sink-counter)
           (cpl:with-failure-handling
               (((or CRAM-COMMON-FAILURES:MANIPULATION-POSE-UNREACHABLE) (e)
                  (setf (btr::pose (btr:get-robot-object))
                        (btr::make-pose
                         (btr::make-3d-vector 0.68 0.6 0.0)
                         (cl-transforms:make-quaternion 0.0 0.0 0.452015 0.89201)))
                   (sleep 1)
                 (cpl:retry)))
             (let* ((?type :bowl)
                    (?name :bowl-1)
                    (?search-there (btr::make-pose-stamped
                                    "map"
                                    0.0
                                    (btr::make-3d-vector 0.9 0.9 0.9)
                                    (btr::make-identity-rotation)))
                    (?more-precise-perceived-object-desig
                      (exe:perform (desig:an action
                                             (type searching)
                                             (object (desig:an object
                                                               (type ?type)
                                                               (name ?name)))
                                             (location (desig:a location 
                                                                (pose ?search-there)))))))
               
               (exe:perform (desig:an action 
                                      (type picking-up)
                                      (object ?more-precise-perceived-object-desig)
                                      (grasp :top)))))
        (let ((bowl-pos (cl-transforms:origin (btr:pose (btr:object
                                      btr:*current-bullet-world*
                                      :bowl-1)))))
          (btr-utils:spawn-object :plate-1 :plate :pose
                                      `((,(cl-transforms:x bowl-pos)
                                         ,(cl-transforms:y bowl-pos)
                                         0.94)
                                        (0 0 0 1))))
        (print "after-picking: attached-objects at the env:")
        (print (btr::attached-objects (btr::get-environment-object)))
        (sleep 5)
        (cram-occasions-events:on-event (make-instance
                                       'cpoe:object-detached-robot 
                                       :arm :right
                                       :object-name :bowl-1))
        (print "after-dropping:attached-objects at the env:")
        (print (btr::attached-objects (btr::get-environment-object)))
        (sleep 5)
        (print "objects should now fly away")
        (dotimes (v 10) 
          (setf 
           (btr:pose (btr:object btr:*current-bullet-world* :plate-1))
           (btr:pose (btr:object btr:*current-bullet-world* :bowl-1)))
          (sleep 1))
        (print "objects should now stay in the air")
        (dotimes (v 10) 
          (setf 
           (btr:pose (btr:object btr:*current-bullet-world* :bowl-1))
           (btr:pose (btr:object btr:*current-bullet-world* :plate-1)))
          (sleep 1))
        (print "now lets drop bowl on the env")
        (spawn-objects-on-sink-counter)
           (cpl:with-failure-handling
               (((or CRAM-COMMON-FAILURES:MANIPULATION-POSE-UNREACHABLE) (e)
                  (setf (btr::pose (btr:get-robot-object))
                        (btr::make-pose
                         (btr::make-3d-vector 0.68 0.6 0.0)
                         (cl-transforms:make-quaternion 0.0 0.0 0.452015 0.89201)))
                   (sleep 1)
                 (cpl:retry)))
             (let* ((?type :bowl)
                    (?name :bowl-1)
                    (?search-there (btr::make-pose-stamped
                                    "map"
                                    0.0
                                    (btr::make-3d-vector 0.9 0.9 0.9)
                                    (btr::make-identity-rotation)))
                    (?more-precise-perceived-object-desig
                      (exe:perform (desig:an action
                                             (type searching)
                                             (object (desig:an object
                                                               (type ?type)
                                                               (name ?name)))
                                             (location (desig:a location 
                                                                (pose ?search-there)))))))
               
               (exe:perform (desig:an action 
                                      (type picking-up)
                                      (object ?more-precise-perceived-object-desig)
                                      (grasp :top)))))
        (print "after-picking: attached-objects at the env:")
        (print (btr::attached-objects (btr::get-environment-object)))
        (sleep 5)
        (cram-occasions-events:on-event (make-instance
                                       'cpoe:object-detached-robot 
                                       :arm :right
                                       :object-name :bowl-1))
        (print "after-dropping:attached-objects at the env:")
        (print (btr::attached-objects (btr::get-environment-object))))
```