### PR TITLE
Drop it to attach

### DIFF
--- a/cram_3d_world/cram_bullet_reasoning/src/items.lisp
+++ b/cram_3d_world/cram_bullet_reasoning/src/items.lisp
@@ -354,8 +354,17 @@ and the other one is loosly attached. "
       (if (equal (car (last already-visited)) (name object))
           (setf already-visited '())))))
 
+(defun object-attached-to-robot-p (object)
+  (when object
+    (assoc (name object) (btr:attached-objects (get-robot-object)))))
+
+(defun get-collision-information-from-robot (object)
+  (declare (type item object))
+  (list (caddr (assoc (name object) (attached-objects (get-robot-object))))))
+
 (defmethod attach-object ((other-object item) (object item)
-                          &key attachment-type loose skip-removing-loose link grasp)
+                          &key attachment-type loose
+                          skip-removing-loose link grasp)
   "Attaches `object' to `other-object': adds an attachment to the
 attached-objects lists of each other. `attachment-type' is a keyword
 that specifies the type of attachment. `loose' specifies if the attachment
@@ -376,7 +385,11 @@ attaching more objects unidirectional and should be for this T. See
               (cons
                (list (make-attachment :object (name object)
                                       :attachment attachment-type))
-               (create-static-collision-information object)))
+               ;; Since robot objects are not in the attached-objects
+               ;; list of items, this has to be copied manuelly:
+               (if (object-attached-to-robot-p object)
+                   (get-collision-information-from-robot object)
+                   (create-static-collision-information object))))
         (slot-value other-object 'attached-objects))
   (push (cons (name other-object)
               (cons
@@ -408,14 +421,16 @@ the element before in `other-objects' and `object'."
            (attachment-object (car (second elem))))
          (get-collision-info (attached obj)
            (cdr (cdr (assoc (name attached) (attached-objects obj))))))
-    (reset-collision-information object (get-collision-info object other-object))
-    (reset-collision-information other-object (get-collision-info other-object object))
-    (setf (slot-value other-object 'attached-objects)
-          (remove (name object) (attached-objects other-object)
-                  :key #'get-attachment-object :test #'equal))
-    (setf (slot-value object 'attached-objects)
-          (remove (name other-object) (attached-objects object)
-                  :key #'get-attachment-object :test #'equal))))
+    (let ((object-collision-info (get-collision-info object other-object))
+          (other-object-collision-info (get-collision-info other-object object)))
+      (setf (slot-value other-object 'attached-objects)
+            (remove (name object) (attached-objects other-object)
+                    :key #'get-attachment-object :test #'equal))
+      (setf (slot-value object 'attached-objects)
+            (remove (name other-object) (attached-objects object)
+                    :key #'get-attachment-object :test #'equal))
+      (reset-collision-information object object-collision-info)
+      (reset-collision-information other-object other-object-collision-info))))
 
 (defmethod detach-all-objects ((object item))
   (with-slots (attached-objects) object

--- a/cram_3d_world/cram_bullet_reasoning/src/objects.lisp
+++ b/cram_3d_world/cram_bullet_reasoning/src/objects.lisp
@@ -358,8 +358,45 @@
       (loop for body in (rigid-bodies object)
             collecting (make-collision-information
                         :rigid-body-name (name body)
-                        :flags (collision-flags body))
-            do (setf (collision-flags body) :cf-static-object))))
+                        :flags (or (when (not (attached-objects object))
+                                     (collision-flags body))
+                                   (if (object-static-in-past-p object)
+                                       '(:cf-static-object)
+                                       NIL)))
+                        do (setf (collision-flags body) :cf-static-object))))
+
+(defun object-static-in-past-p (object)
+  "Returns if the `object's flags were `cf-static-object' at the
+beginning or if its flags were set to `cf-static-object', because
+it was attached to other objects. Returns T, if `object's flags were
+always `cf-static-object', else NIL."
+  (declare (type object object))
+  (let* ((attached-object-names (mapcar #'car (attached-objects
+                                               (object
+                                                *current-bullet-world*
+                                                (name object)))))
+         (attachments-of-attached-objects 
+           (mapcar #'attached-objects (mapcar (alexandria:curry #'object
+                                                                *current-bullet-world*)
+                                                  attached-object-names)))
+         (attachments-to-object
+           (mapcar #'car
+                   (loop for attachments in attachments-of-attached-objects
+                         collecting
+                         (remove-if-not (lambda (attach)
+                                          (equalp (car
+                                                   attach)
+                                                  (name object)))
+                                        attachments))))
+         (collision-information-list 
+           (remove-if-not #'identity (mapcar #'caddr attachments-to-object))))
+
+    (when collision-information-list
+      (every (alexandria:curry #'equalp '(:cf-static-object))
+             (mapcar
+              #'collision-information-flags
+              collision-information-list)))))
+  
 
 (defmethod reset-collision-information ((object object) collision-information)
   (loop for collision-data in collision-information
@@ -367,7 +404,10 @@
                     object (collision-information-rigid-body-name
                             collision-data))
         do (setf (collision-flags body)
-                 (collision-information-flags collision-data))))
+                 (or 
+                  (when (attached-objects object)
+                    '(:cf-static-object))
+                  (collision-information-flags collision-data)))))
 
 
 (defstruct attachment

--- a/cram_common/cram_manipulation_interfaces/src/manipulation-interfaces.lisp
+++ b/cram_common/cram_manipulation_interfaces/src/manipulation-interfaces.lisp
@@ -81,3 +81,11 @@ is considered closed.
 `container-designator' is a designator describing the container.")
   (:method :heuristics 20 (container-name)
     nil))
+
+(defgeneric get-z-offset-for-placing-distance (other-object object attachment)
+  (:method-combination cut:first-in-order-and-around)
+  (:documentation "Returns a z offset in map for given `object' for
+  placing or dropping it on the `other-object'.")
+  (:method :heuristics 20 (other-object object attachment)
+    0.0))
+  

--- a/cram_common/cram_manipulation_interfaces/src/package.lisp
+++ b/cram_common/cram_manipulation_interfaces/src/package.lisp
@@ -55,6 +55,7 @@
    #:get-location-poses
    #:get-container-opening-distance
    #:get-container-closing-distance
+   #:get-z-offset-for-placing-distance
    ;; grasps
    #:calculate-object-faces
    #:calculate-face-vector

--- a/cram_common/cram_manipulation_interfaces/src/trajectories.lisp
+++ b/cram_common/cram_manipulation_interfaces/src/trajectories.lisp
@@ -306,8 +306,6 @@ Gripper is defined by a convention where Z is pointing towards the object.")
            (desig:desig-prop-value object :type))
          (maybe-other-object
            (car (cdr objects-acted-on)))
-         (maybe-other-object-name
-           (desig:desig-prop-value maybe-other-object :name))
          (maybe-other-object-type
            (desig:desig-prop-value maybe-other-object :type))
          (maybe-attachment
@@ -319,6 +317,7 @@ Gripper is defined by a convention where Z is pointing towards the object.")
          (oTg-std
            (get-object-type-to-gripper-transform
             object-type object-name arm grasp)))
+             
 
     ;; Add z-offset for dropping items on other items
     (setf (slot-value
@@ -326,7 +325,8 @@ Gripper is defined by a convention where Z is pointing towards the object.")
             oTg-std
             'cl-tf:translation)
            'cl-tf:z)
-          (+ (cl-tf:z (cl-tf:translation oTg-std))
+          (+ (cl-tf:z (cl-tf:copy-3d-vector
+                       (cl-tf:translation oTg-std)))
              z-offset))
 
     (mapcar (lambda (label transforms)

--- a/cram_common/cram_manipulation_interfaces/src/trajectories.lisp
+++ b/cram_common/cram_manipulation_interfaces/src/trajectories.lisp
@@ -315,19 +315,20 @@ Gripper is defined by a convention where Z is pointing towards the object.")
                     object-type
                     maybe-attachment))
          (oTg-std
-           (get-object-type-to-gripper-transform
-            object-type object-name arm grasp)))
-             
-
-    ;; Add z-offset for dropping items on other items
-    (setf (slot-value
-           (slot-value
-            oTg-std
-            'cl-tf:translation)
-           'cl-tf:z)
-          (+ (cl-tf:z (cl-tf:copy-3d-vector
-                       (cl-tf:translation oTg-std)))
-             z-offset))
+           (let ((tmp-oTg-std (get-object-type-to-gripper-transform
+                               object-type object-name arm grasp)))
+             (cl-tf:transform->stamped-transform
+              (cl-tf:frame-id tmp-oTg-std)
+              (cl-tf:child-frame-id tmp-oTg-std)
+              (cl-tf:stamp tmp-oTg-std)
+              (cl-tf:make-transform
+               (cl-tf:make-3d-vector
+                (cl-tf:x (cl-tf:translation tmp-oTg-std))
+                (cl-tf:y (cl-tf:translation tmp-oTg-std))
+                (+ (cl-tf:z (cl-tf:translation tmp-oTg-std))
+                   z-offset))
+               (cl-tf:copy-quaternion
+                (cl-tf:rotation tmp-oTg-std)))))))
 
     (mapcar (lambda (label transforms)
               (make-traj-segment

--- a/cram_common/cram_manipulation_interfaces/src/trajectories.lisp
+++ b/cram_common/cram_manipulation_interfaces/src/trajectories.lisp
@@ -304,9 +304,30 @@ Gripper is defined by a convention where Z is pointing towards the object.")
            (desig:desig-prop-value object :name))
          (object-type
            (desig:desig-prop-value object :type))
+         (maybe-other-object
+           (car (cdr objects-acted-on)))
+         (maybe-other-object-name
+           (desig:desig-prop-value maybe-other-object :name))
+         (maybe-other-object-type
+           (desig:desig-prop-value maybe-other-object :type))
+         (maybe-attachment
+           (car (cdr (cdr objects-acted-on))))
+         (z-offset (get-z-offset-for-placing-distance
+                    maybe-other-object-type
+                    object-type
+                    maybe-attachment))
          (oTg-std
            (get-object-type-to-gripper-transform
             object-type object-name arm grasp)))
+
+    ;; Add z-offset for dropping items on other items
+    (setf (slot-value
+           (slot-value
+            oTg-std
+            'cl-tf:translation)
+           'cl-tf:z)
+          (+ (cl-tf:z (cl-tf:translation oTg-std))
+             z-offset))
 
     (mapcar (lambda (label transforms)
               (make-traj-segment

--- a/cram_common/cram_mobile_pick_place_plans/src/pick-place-designators.lisp
+++ b/cram_common/cram_mobile_pick_place_plans/src/pick-place-designators.lisp
@@ -164,7 +164,9 @@
         (cpoe:object-in-hand ?object-designator ?arm ?grasp))
 
     ;; calculate trajectory
-    (equal ?objects (?current-object-designator))
+    (equal ?objects (?current-object-designator
+                     ?other-object-designator
+                     ?placement-location-name))
     (-> (equal ?arm :left)
         (and (lisp-fun man-int:get-action-trajectory
                        :placing ?arm ?grasp ?objects

--- a/cram_common/cram_object_knowledge/src/assembly.lisp
+++ b/cram_common/cram_object_knowledge/src/assembly.lisp
@@ -246,6 +246,12 @@
                                 )
   :attachment-rot-matrix man-int:*identity-matrix*)
 
+(defmethod man-int::get-z-offset-for-placing-distance :heuristics 20
+  ((other-object (eql :chassis))
+   (object (eql :bottom-wing))
+   (attachment (eql :wing-attachment)))
+  0.02)
+
 (man-int:def-object-type-in-other-object-transform :underbody :bottom-wing :body-attachment
   :attachment-translation `(0.0 -0.025 0.02)
   :attachment-rot-matrix man-int:*rotation-around-z+90-matrix*)

--- a/cram_common/cram_object_knowledge/src/assembly.lisp
+++ b/cram_common/cram_object_knowledge/src/assembly.lisp
@@ -246,7 +246,7 @@
                                 )
   :attachment-rot-matrix man-int:*identity-matrix*)
 
-(defmethod man-int::get-z-offset-for-placing-distance :heuristics 20
+(defmethod man-int:get-z-offset-for-placing-distance :heuristics 20
   ((other-object (eql :chassis))
    (object (eql :bottom-wing))
    (attachment (eql :wing-attachment)))


### PR DESCRIPTION
## Functionality & Tests

This PR adds the generic function `get-z-offset-for-placing-distance` making it possible to define z offsets for placing tasks. As an example one can add the following line
```

(format t "dropping from ~A to safe pose ~A" (btr:pose btr-object) object-in-map-pose)
(break)

```
 in `cram_manipulation_interfaces:event-handlers.lisp` line 130 and execute the `demo` in `cram_boxy_assembly_demo`. The object `bottom-wing' will be placed above the `chassis` object and after that will be "simulated" in its real position. The difference can be seen in the z values of both poses.

One more example is shown in https://github.com/cram2/cram/pull/140. 

## Bug: lost collision-information 

https://github.com/cram2/cram/pull/140 revealed a bug too. If a non-stable object was grasped from the robot and placed in the basket, it would fall although it is attached to the basket. The reason for this was that the "non-stable" collision-information was reset in the (detach-object rob obj) call. Because the attachment from the object to the basket was made before the detachment, the object was not set again to be stable in btr.

### Fix
 
To keep the collision-information from the object valid and consistent, code was written in this PR (https://github.com/cram2/cram/pull/150/commits/667b90b214d279c03596c606b0b5bfe23c61ca33). Since the bug affects only items, these changes were made in items.lisp and objects.lisp.

#### items.lisp:

* attach-object: Since items are not connected through their attached-objects to robots, items try to get their collision-information from the robot if they attach to another item.
* detach-object: Detaching other-object from object before resetting the collision-information. 

#### object.lisp

* create-static-collision-information: If the item i has no attached objects, the collision-information from btr gets gathered. Else the attached-objects of i will be checked. If i was marked as static in any of i's attached objects, it was once a static object.

* reset-static-collision-information: If the item got attached-objects, it should be static, else the collision-information gets loaded in the object. 
