### PR TITLE
Fix env man distance calculation

### DIFF
--- a/cram_3d_world/cram_urdf_environment_manipulation/src/plans.lisp
+++ b/cram_3d_world/cram_urdf_environment_manipulation/src/plans.lisp
@@ -105,7 +105,7 @@
   (when (eq ?type :opening)
     (exe:perform
      (desig:an action
-               (type closing-gripper)
+               (type gripping)
                (gripper ?arm))))
 
   ;;;;;;;;;;;;;;;;;;;;;; MANIPULATING ;;;;;;;;;;;;;;;;;;;;;;;

--- a/cram_3d_world/cram_urdf_environment_manipulation/src/plans.lisp
+++ b/cram_3d_world/cram_urdf_environment_manipulation/src/plans.lisp
@@ -101,10 +101,11 @@
                (link ?link-name)
                (left-poses ?left-grasp-poses)
                (right-poses ?right-grasp-poses))))
+
   (when (eq ?type :opening)
     (exe:perform
      (desig:an action
-               (type gripping)
+               (type closing-gripper)
                (gripper ?arm))))
 
   ;;;;;;;;;;;;;;;;;;;;;; MANIPULATING ;;;;;;;;;;;;;;;;;;;;;;;

--- a/cram_3d_world/cram_urdf_environment_manipulation/src/plans.lisp
+++ b/cram_3d_world/cram_urdf_environment_manipulation/src/plans.lisp
@@ -38,8 +38,8 @@
                                ((:right-reach-poses ?right-reach-poses))
                                ((:left-grasp-poses ?left-grasp-poses))
                                ((:right-grasp-poses ?right-grasp-poses))
-                               ((:left-open-poses ?left-manipulate-poses))
-                               ((:right-open-poses ?right-manipulate-poses))
+                               ((:left-manipulate-poses ?left-manipulate-poses))
+                               ((:right-manipulate-poses ?right-manipulate-poses))
                                ((:left-retract-poses ?left-retract-poses))
                                ((:right-retract-poses ?right-retract-poses))
                                joint-name

--- a/cram_common/cram_mobile_pick_place_plans/src/atomic-action-designators.lisp
+++ b/cram_common/cram_mobile_pick_place_plans/src/atomic-action-designators.lisp
@@ -178,6 +178,13 @@
     (once (or (spec:property ?action-designator (:object ?_))
               (true))))
 
+  (<- (desig:action-grounding ?action-designator (grip ?action-designator))
+    (spec:property ?action-designator (:type :gripping))
+    (spec:property ?action-designator (:gripper ?_))
+    (not (spec:property ?action-designator (:object ?_)))
+    (once (or (spec:property ?action-designator (:effort ?_))
+              (true))))
+
   (<- (desig:action-grounding ?action-designator (grip ?augmented-action-designator))
     (spec:property ?action-designator (:type :gripping))
     (spec:property ?action-designator (:gripper ?_))

--- a/cram_common/cram_mobile_pick_place_plans/src/atomic-action-plans.lisp
+++ b/cram_common/cram_mobile_pick_place_plans/src/atomic-action-plans.lisp
@@ -247,13 +247,15 @@ In any case, issue ROBOT-STATE-CHANGED event."
                      (desig:when ?effort
                        (effort ?effort))))
            (roslisp:ros-info (pick-place grip) "Assert grasp into knowledge base")
-           (cram-occasions-events:on-event
-            (make-instance 'cpoe:object-attached-robot
-              :arm ?left-or-right
-              :object-name (desig:desig-prop-value object-designator :name)
-              :grasp ?grasp))
-           (desig:equate object-designator new-object-designator)
-           new-object-designator))
+
+           (when object-designator
+             (cram-occasions-events:on-event
+              (make-instance 'cpoe:object-attached-robot
+                             :arm ?left-or-right
+                             :object-name (desig:desig-prop-value object-designator :name)
+                             :grasp ?grasp))
+             (desig:equate object-designator new-object-designator)
+             new-object-designator)))
     (cram-occasions-events:on-event
      (make-instance 'cram-plan-occasions-events:robot-state-changed))))
 


### PR DESCRIPTION
Problem was that the distance calculation did not distinguish between prismatic and revolute joints. So a mod 2*pi was performed on the joint state of prismatic joints. (this was intended for revolute joints, because bullet assigns them negative numbers sometimes, to keep them in the 0-2pi range.)
This lead to very large distances for the opening and closing of prismatic joint containers.

~~This also fixes a little bug in the env man plan, which was not closing the gripper, because the wrong designator was used.~~

This also makes the object designator needed in the gripping action optional, so that the env-man plan can still use gripping and have the benefits without needing to provide an object that is being gripped. (Because attaching a container to the gripper would be not good.)

Also fixes a small typo in the environment manipulation plan.