### PR TITLE
[env-man] Use range costmap instead of gaussian for reachability.

### DIFF
--- a/cram_pr2/cram_pr2_description/src/pr2-knowledge.lisp
+++ b/cram_pr2/cram_pr2_description/src/pr2-knowledge.lisp
@@ -72,6 +72,6 @@
                                            costmap:visibility-costmap-size)
   (<- (costmap:costmap-padding 0.3))
   (<- (costmap:costmap-manipulation-padding 0.4))
-  (<- (costmap:costmap-in-reach-distance 0.9))
+  (<- (costmap:costmap-in-reach-distance 1.0))
   (<- (costmap:costmap-reach-minimal-distance 0.2))
   (<- (costmap:visibility-costmap-size 2)))


### PR DESCRIPTION
This changes the costmaps for both prismatic and revolute joint containers to use the range costmap instead of a gaussian for reachability. This makes much more sense and should make the costmaps more stable. But it might be necessary to make sure the costmap metaparameters are sound (minimal and maximum reaching distance).
Testing included opening drawers and the fridge with both arms of PR2 and Boxy. Especially the left upper drawer with the right arm and the trash drawer with the left arm were tested thoroughly.

This PR also increases the PR2's in-reach-distance by 10cm to make the costmap work.