### PR TITLE
Lift transform in grasping trajectory fixed 

### DIFF
--- a/cram_common/cram_manipulation_interfaces/src/package.lisp
+++ b/cram_common/cram_manipulation_interfaces/src/package.lisp
@@ -74,6 +74,7 @@
    #:get-object-type-to-gripper-transform
    #:get-object-type-to-gripper-pregrasp-transform
    #:get-object-type-to-gripper-2nd-pregrasp-transform
+   #:get-object-type-fixed-frame-lift-transforms
    #:get-object-type-to-gripper-lift-transform
    #:get-object-type-to-gripper-2nd-lift-transform
    #:def-object-type-to-gripper-transforms

--- a/cram_common/cram_manipulation_interfaces/src/trajectories.lisp
+++ b/cram_common/cram_manipulation_interfaces/src/trajectories.lisp
@@ -358,7 +358,7 @@ just need to return a list containing poses encoded as lists."
          (mTrob-base
            (costmap::pose-stamped->transform-stamped 
             (cram-tf:robot-current-pose)
-            btr::*robot-base-frame*))
+            cram-tf:*robot-base-frame*))
          (mTo 
            (cram-tf:apply-transform mTrob-base rob-baseTo))
          (oTm

--- a/cram_common/cram_manipulation_interfaces/src/trajectories.lisp
+++ b/cram_common/cram_manipulation_interfaces/src/trajectories.lisp
@@ -341,8 +341,7 @@ just need to return a list containing poses encoded as lists."
                                                  arm
                                                  grasp
                                                  objects-acted-on
-                                                 &key
-                                                   target-object-transform-in-base)
+                                                 &key target-object-transform-in-base)
   
   (let* ((object
            (car objects-acted-on))

--- a/cram_common/cram_object_knowledge/src/household.lisp
+++ b/cram_common/cram_object_knowledge/src/household.lisp
@@ -99,6 +99,43 @@
   :lift-offsets `(0.0 0.0 ,*cutlery-pregrasp-z-offset*)
   :2nd-lift-offsets `(0.0 0.0 ,*cutlery-pregrasp-z-offset*))
 
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :cutlery))
+                                                                 object-name
+                                                                 arm
+                                                                 (grasp (eql :top)))
+  `((,*lift-offset*
+     (0 0 0 1))
+    (,*lift-offset*
+     (0 0 0 1))))
+
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :fork))
+                                                                 object-name
+                                                                 arm
+                                                                 (grasp (eql :top)))
+  `((,*lift-offset*
+     (0 0 0 1))
+    (,*lift-offset*
+     (0 0 0 1))))
+
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :knife))
+                                                                 object-name
+                                                                 arm
+                                                                 (grasp (eql :top)))
+  `((,*lift-offset*
+     (0 0 0 1))
+    (,*lift-offset*
+     (0 0 0 1))))
+
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :spoon))
+                                                                 object-name
+                                                                 arm
+                                                                 (grasp (eql :top)))
+  `((,*lift-offset*
+     (0 0 0 1))
+    (,*lift-offset*
+     (0 0 0 1))))
+
+
 ;; BOTTOM grasp
 ;; Bottom grasp is commented out because the robot grasps the spoon through the
 ;; drawer, as in the last part of the grasping trajectory collisions are turned off
@@ -119,6 +156,8 @@
 (defparameter *plate-grasp-roll-offset* (/ pi 6))
 (defparameter *plate-pregrasp-y-offset* 0.2 "in meters")
 (defparameter *plate-2nd-pregrasp-z-offset* 0.03 "in meters") ; grippers can't go into table
+
+
 
 ;; SIDE grasp
 (man-int:def-object-type-to-gripper-transforms '(:plate :tray) :left :left-side
@@ -142,6 +181,34 @@
   :lift-offsets *lift-offset*
   :2nd-lift-offsets *lift-offset*)
 
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :plate))
+                                                                 object-name
+                                                                 (arm (eql :left))
+                                                                 (grasp (eql :left-side)))
+  `((,*lift-offset*
+     (0 0 0 1))
+    (,*lift-offset*
+     (0 0 0 1))))
+
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :tray))
+                                                                 object-name
+                                                                 (arm (eql :left))
+                                                                 (grasp (eql :left-side)))
+  `((,*lift-offset*
+     (0 0 0 1))
+    (,*lift-offset*
+     (0 0 0 1))))
+
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :plate))
+                                                                 object-name
+                                                                 (arm (eql :right))
+                                                                 (grasp (eql :right-side)))
+  `((,*lift-offset*
+     (0 0 0 1))
+    (,*lift-offset*
+     (0 0 0 1))))
+
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; bottle ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defparameter *bottle-pregrasp-xy-offset* 0.15 "in meters")
@@ -164,6 +231,44 @@
   :lift-offsets *lift-offset*
   :2nd-lift-offsets *lift-offset*)
 
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :bottle))
+                                                                 object-name
+                                                                 arm
+                                                                 (grasp (eql :left-side)))
+  `((,*lift-offset*
+     (0 0 0 1))
+    (,*lift-offset*
+     (0 0 0 1))))
+
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :drink))
+                                                                 object-name
+                                                                 arm
+                                                                 (grasp (eql :left-side)))
+  `((,*lift-offset*
+     (0 0 0 1))
+    (,*lift-offset*
+     (0 0 0 1))))
+
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :bottle))
+                                                                 object-name
+                                                                 arm
+                                                                 (grasp (eql :right-side)))
+  `((,*lift-offset*
+     (0 0 0 1))
+    (,*lift-offset*
+     (0 0 0 1))))
+
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :drink))
+                                                                 object-name
+                                                                 arm
+                                                                 (grasp (eql :right-side)))
+  `((,*lift-offset*
+     (0 0 0 1))
+    (,*lift-offset*
+     (0 0 0 1))))
+
+
+
 ;; BACK grasp
 (man-int:def-object-type-to-gripper-transforms '(:drink :bottle) '(:left :right) :back
   :grasp-translation `(,*bottle-grasp-xy-offset* 0.0d0 ,*bottle-grasp-z-offset*)
@@ -172,6 +277,24 @@
   :2nd-pregrasp-offsets `(,(- *bottle-pregrasp-xy-offset*) 0.0 0.0)
   :lift-offsets *lift-offset*
   :2nd-lift-offsets *lift-offset*)
+
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :bottle))
+                                                                 object-name
+                                                                 arm
+                                                                 (grasp (eql :back)))
+  `((,*lift-offset*
+     (0 0 0 1))
+    (,*lift-offset*
+     (0 0 0 1))))
+
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :drink))
+                                                                 object-name
+                                                                 arm
+                                                                 (grasp (eql :back)))
+  `((,*lift-offset*
+     (0 0 0 1))
+    (,*lift-offset*
+     (0 0 0 1))))
 
 ;; FRONT grasp
 (man-int:def-object-type-to-gripper-transforms '(:drink :bottle) '(:left :right) :front
@@ -182,6 +305,24 @@
   :lift-offsets *lift-offset*
   :2nd-lift-offsets *lift-offset*)
 
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :bottle))
+                                                                 object-name
+                                                                 arm
+                                                                 (grasp (eql :front)))
+  `((,*lift-offset*
+     (0 0 0 1))
+    (,*lift-offset*
+     (0 0 0 1))))
+
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :drink))
+                                                                 object-name
+                                                                 arm
+                                                                 (grasp (eql :front)))
+  `((,*lift-offset*
+     (0 0 0 1))
+    (,*lift-offset*
+     (0 0 0 1))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; cup ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defparameter *cup-pregrasp-xy-offset* 0.15 "in meters")
@@ -189,6 +330,7 @@
 (defparameter *cup-grasp-z-offset* 0.01 "in meters")
 (defparameter *cup-top-grasp-x-offset* 0.03 "in meters")
 (defparameter *cup-top-grasp-z-offset* 0.02 "in meters")
+
 
 ;; TOP grasp
 (man-int:def-object-type-to-gripper-transforms :cup '(:left :right) :top
@@ -198,6 +340,15 @@
   :2nd-pregrasp-offsets *lift-offset*
   :lift-offsets *lift-offset*
   :2nd-lift-offsets *lift-offset*)
+
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :cup))
+                                                                 object-name
+                                                                 arm
+                                                                 (grasp (eql :top)))
+  `((,*lift-offset*
+     (0 0 0 1))
+    (,*lift-offset*
+     (0 0 0 1))))
 
 ;; SIDE grasp
 (man-int:def-object-type-to-gripper-transforms :cup '(:left :right) :left-side
@@ -215,6 +366,24 @@
   :lift-offsets *lift-offset*
   :2nd-lift-offsets *lift-offset*)
 
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :cup))
+                                                                 object-name
+                                                                 arm
+                                                                 (grasp (eql :left-side)))
+  `((,*lift-offset*
+     (0 0 0 1))
+    (,*lift-offset*
+     (0 0 0 1))))
+
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :cup))
+                                                                 object-name
+                                                                 arm
+                                                                 (grasp (eql :right-side)))
+  `((,*lift-offset*
+     (0 0 0 1))
+    (,*lift-offset*
+     (0 0 0 1))))
+
 ;; BACK grasp
 (man-int:def-object-type-to-gripper-transforms :cup '(:left :right) :back
   :grasp-translation `(,*cup-grasp-xy-offset* 0.0d0 ,*cup-grasp-z-offset*)
@@ -223,6 +392,15 @@
   :2nd-pregrasp-offsets `(,(- *cup-pregrasp-xy-offset*) 0.0 0.0)
   :lift-offsets *lift-offset*
   :2nd-lift-offsets *lift-offset*)
+
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :cup))
+                                                                 object-name
+                                                                 arm
+                                                                 (grasp (eql :back)))
+  `((,*lift-offset*
+     (0 0 0 1))
+    (,*lift-offset*
+     (0 0 0 1))))
 
 ;; FRONT grasp
 (man-int:def-object-type-to-gripper-transforms :cup '(:left :right) :front
@@ -233,6 +411,14 @@
   :lift-offsets *lift-offset*
   :2nd-lift-offsets *lift-offset*)
 
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :cup))
+                                                                 object-name
+                                                                 arm
+                                                                 (grasp (eql :front)))
+  `((,*lift-offset*
+     (0 0 0 1))
+    (,*lift-offset*
+     (0 0 0 1))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; milk ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -250,6 +436,16 @@
   :lift-offsets *lift-offset*
   :2nd-lift-offsets *lift-offset*)
 
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :milk))
+                                                                 object-name
+                                                                 arm
+                                                                 (grasp (eql :back)))
+  `((,*lift-offset*
+     (0 0 0 1))
+    (,*lift-offset*
+     (0 0 0 1))))
+
+
 ;; FRONT grasp
 (man-int:def-object-type-to-gripper-transforms :milk '(:left :right) :front
   :grasp-translation `(,(- *milk-grasp-xy-offset*) 0.0d0 ,*milk-grasp-z-offset*)
@@ -258,6 +454,15 @@
   :2nd-pregrasp-offsets `(,*milk-pregrasp-xy-offset* 0.0 0.0)
   :lift-offsets *lift-offset*
   :2nd-lift-offsets *lift-offset*)
+
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :milk))
+                                                                 object-name
+                                                                 arm
+                                                                 (grasp (eql :front)))
+  `((,*lift-offset*
+     (0 0 0 1))
+    (,*lift-offset*
+     (0 0 0 1))))
 
 ;; SIDE grasp
 (man-int:def-object-type-to-gripper-transforms :milk '(:left :right) :left-side
@@ -275,6 +480,23 @@
   :lift-offsets `(0.0 ,*milk-grasp-xy-offset* ,*milk-lift-z-offset*)
   :2nd-lift-offsets `(0.0 ,*milk-grasp-xy-offset* ,*milk-lift-z-offset*))
 
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :milk))
+                                                                 object-name
+                                                                 arm
+                                                                 (grasp (eql :left-side)))
+  `(((0.0 ,(- *milk-grasp-xy-offset*) ,*milk-lift-z-offset*)
+     (0 0 0 1))
+    ((0.0 ,(- *milk-grasp-xy-offset*) ,*milk-lift-z-offset*)
+     (0 0 0 1))))
+
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :milk))
+                                                                 object-name
+                                                                 arm
+                                                                 (grasp (eql :right-side)))
+  `(((0.0 ,*milk-grasp-xy-offset* ,*milk-lift-z-offset*)
+     (0 0 0 1))
+    ((0.0 ,*milk-grasp-xy-offset* ,*milk-lift-z-offset*)
+     (0 0 0 1))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; cereal ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cram_common/cram_object_knowledge/src/household.lisp
+++ b/cram_common/cram_object_knowledge/src/household.lisp
@@ -233,6 +233,7 @@
   :lift-offsets *lift-offset*
   :2nd-lift-offsets *lift-offset*)
 
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; milk ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defparameter *milk-grasp-xy-offset* 0.01 "in meters")
@@ -274,6 +275,7 @@
   :lift-offsets `(0.0 ,*milk-grasp-xy-offset* ,*milk-lift-z-offset*)
   :2nd-lift-offsets `(0.0 ,*milk-grasp-xy-offset* ,*milk-lift-z-offset*))
 
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; cereal ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defparameter *cereal-grasp-z-offset* 0.04 "in meters")
@@ -292,6 +294,24 @@
   :lift-offsets `(,*cereal-grasp-xy-offset* 0.0 ,*cereal-lift-z-offset*)
   :2nd-lift-offsets `(,*cereal-postgrasp-xy-offset* 0.0 ,*cereal-lift-z-offset*))
 
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :breakfast-cereal))
+                                                                 object-name
+                                                                 arm
+                                                                 (grasp (eql :front)))
+  `(((,*cereal-grasp-xy-offset* 0.0 ,*cereal-lift-z-offset*)
+     (0 0 0 1))
+    ((,*cereal-postgrasp-xy-offset* 0.0 ,*cereal-lift-z-offset*)
+     (0 0 0 1))))
+
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :cereal))
+                                                                 object-name
+                                                                 arm
+                                                                 (grasp (eql :front)))
+  `(((,*cereal-grasp-xy-offset* 0.0 ,*cereal-lift-z-offset*)
+     (0 0 0 1))
+    ((,*cereal-postgrasp-xy-offset* 0.0 ,*cereal-lift-z-offset*)
+     (0 0 0 1))))
+
 ;; TOP grasp
 (man-int:def-object-type-to-gripper-transforms '(:cereal :breakfast-cereal) '(:left :right) :top
   :grasp-translation `(0.0d0 0.0d0 ,*cereal-grasp-z-offset*)
@@ -301,6 +321,24 @@
   :lift-offsets *lift-offset*
   :2nd-lift-offsets *lift-offset*)
 
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :breakfast-cereal))
+                                                                 object-name
+                                                                 arm
+                                                                 (grasp (eql :top)))
+  `((,*lift-offset*
+     (0 0 0 1))
+    (,*lift-offset*
+     (0 0 0 1))))
+
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :cereal))
+                                                                 object-name
+                                                                 arm
+                                                                 (grasp (eql :top)))
+  `((,*lift-offset*
+     (0 0 0 1))
+    (,*lift-offset*
+     (0 0 0 1))))
+
 ;; BACK grasp
 (man-int:def-object-type-to-gripper-transforms '(:cereal :breakfast-cereal) '(:left :right) :back
   :grasp-translation `(,(- *cereal-grasp-xy-offset*) 0.0d0 ,*cereal-grasp-z-offset*)
@@ -309,6 +347,24 @@
   :2nd-pregrasp-offsets `(,(- *cereal-pregrasp-xy-offset*) 0.0 0.0)
   :lift-offsets `(,(- *cereal-grasp-xy-offset*) 0.0 ,*cereal-lift-z-offset*)
   :2nd-lift-offsets `(,(- *cereal-postgrasp-xy-offset*) 0.0 ,*cereal-lift-z-offset*))
+
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :breakfast-cereal))
+                                                                 object-name
+                                                                 arm
+                                                                 (grasp (eql :back)))
+  `(((,(- *cereal-grasp-xy-offset*) 0.0 ,*cereal-lift-z-offset*)
+     (0 0 0 1))
+    ((,(- *cereal-postgrasp-xy-offset*) 0.0 ,*cereal-lift-z-offset*)
+     (0 0 0 1))))
+
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :cereal))
+                                                                 object-name
+                                                                 arm
+                                                                 (grasp (eql :back)))
+  `(((,(- *cereal-grasp-xy-offset*) 0.0 ,*cereal-lift-z-offset*)
+     (0 0 0 1))
+    ((,(- *cereal-postgrasp-xy-offset*) 0.0 ,*cereal-lift-z-offset*)
+     (0 0 0 1))))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;; bowl ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -325,3 +381,12 @@
   :2nd-pregrasp-offsets `(0.0 0.0 ,*bowl-pregrasp-z-offset*)
   :lift-offsets `(0.0 0.0 ,*bowl-pregrasp-z-offset*)
   :2nd-lift-offsets `(0.0 0.0 ,*bowl-pregrasp-z-offset*))
+
+(defmethod man-int::get-object-type-fixed-frame-lift-transforms ((object-type (eql :bowl))
+                                                                 object-name
+                                                                 arm
+                                                                 (grasp (eql :top)))
+  `(((0.0 0.0 ,*bowl-pregrasp-z-offset*)
+     (0 0 0 1))
+    ((0.0 0.0 ,*bowl-pregrasp-z-offset*)
+     (0 0 0 1))))


### PR DESCRIPTION
[Trello card](https://trello.com/c/UBRmCBbS)

This PR adds the function `man-int:get-object-type-fixed-frame-lift-transforms`. Since it is not possible to calculate `oTg-std` with an offset in `z_map` with the methods from `man-int:get-object-type-to-gripper-transform`, the above function was defined and implemented in` manipulation-interfaces::trajectories.lisp` as a generic and instantiated for different objects in `cram_object_knowledge::household.lisp`. Moreover, to make it more convenient defining the `man-int:get-object-type-fixed-frame-lift-transforms` methods for different object-types, object-names, arms or grasps, only a list of two poses encoded as lists too has to be returned (see cram_object_knowledge e.g.).

`man-int:get-object-type-fixed-frame-lift-transforms` is then called in `manipulation-interfaces:get-action-trajectory` for placing or picking-up actions.

Tested with these methods:

```
(defun reset ()
        (btr:detach-all-objects (btr:get-robot-object))
        (btr-utils:kill-all-objects)
        (urdf-proj:with-simulated-robot (park-robot)))
```

```
(defun pick-n-place-support-bottom (left-p)
"puts bowl object supported from the bottom on the side"
        (btr-utils:spawn-object :b :bowl
                                :pose `((0.4 0 0.85)(0 0 0 1)))
        (setf (cl-bullet:collision-flags 
               (first (btr:rigid-bodies (btr:object
                                         btr:*current-bullet-world*
                                         :b))))
              '(:cf-static-object))
          (let* ((y-diff (if left-p
                             0.2
                             -0.2))
                 (?arm (if left-p
                           :left
                           :right))
                 (?type :bowl)
                 (?name :b)
                 (?search-there (btr::make-pose-stamped
                                 "map"
                                 0.0
                                 (btr::make-3d-vector 0.4 0.0 0.85)
                                 (btr::make-quaternion 0 0 0 1)))
                 (?place-there (btr::make-pose-stamped
                                "map"
                                0.0
                                (btr::make-3d-vector 0.4 y-diff 0.85)
                                (btr::make-quaternion (if left-p -1 1) 0 0 1)))
                 (?more-precise-perceived-object-desig
                   (exe:perform (desig:an action
                                          (type searching)
                                          (object (desig:an object
                                                            (type ?type)
                                                            (name ?name)))
                                          (location (desig:a location 
                                                             (pose ?search-there)))))))
            
            (exe:perform (desig:an action 
                                   (type picking-up)
                                   (object
                                    ?more-precise-perceived-object-desig)
                                   (arm ?arm)
                                   (grasp :top)))
            (print "now placing bowl")
            (sleep 2)
            (exe:perform (desig:an action 
                                   (type placing)
                                   (object ?more-precise-perceived-object-desig)
                                   (target (desig:an location 
                                                     (pose ?place-there)))
                                   (arm ?arm)
                                   (grasp :top)))))
```
```
(defun pick-n-place-support-side (left-p)
"puts bowl object supported from the side on the bottom"
        (btr-utils:spawn-object :b :bowl
                                :pose `((0.4 0 0.85)(,(if left-p -1 1) 0 0 1)))
        (setf (cl-bullet:collision-flags 
               (first (btr:rigid-bodies (btr:object
                                         btr:*current-bullet-world*
                                         :b))))
              '(:cf-static-object))
          (let* ((y-diff (if left-p
                             0.2
                             -0.2))
                 (?arm (if left-p
                           :left
                           :right))
                 (?type :bowl)
                 (?name :b)
                 (?search-there (btr::make-pose-stamped
                                 "map"
                                 0.0
                                 (btr::make-3d-vector 0.4 0.0 0.85)
                                 (btr::make-quaternion 0 0 0 1)))
                 (?place-there (btr::make-pose-stamped
                                "map"
                                0.0
                                (btr::make-3d-vector 0.4 y-diff 0.85)
                                (btr::make-quaternion 0 0 0 1)))
                 (?more-precise-perceived-object-desig
                   (exe:perform (desig:an action
                                          (type searching)
                                          (object (desig:an object
                                                            (type ?type)
                                                            (name ?name)))
                                          (location (desig:a location 
                                                             (pose ?search-there)))))))
            
            (exe:perform (desig:an action 
                                   (type picking-up)
                                   (object
                                    ?more-precise-perceived-object-desig)
                                   (arm ?arm)
                                   (grasp :top)))
            (print "now placing bowl")
            (sleep 2)
            (exe:perform (desig:an action 
                                   (type placing)
                                   (object ?more-precise-perceived-object-desig)
                                   (target (desig:an location 
                                                     (pose ?place-there)))
                                   (arm ?arm)
                                   (grasp :top)))))
```
if the parameter left-p is T it will use the left hand, else the right hand.
```
(reset) (urdf-proj:with-projected-robot (pick-n-place-support-bottom nil))
```

```
(reset) (urdf-proj:with-projected-robot (pick-n-place-support-bottom t))
```

```
(reset) (urdf-proj:with-projected-robot (pick-n-place-support-side t))
```
```
(reset) (urdf-proj:with-projected-robot (pick-n-place-support-side nil))
```