### PR TITLE
[external_interface]Adding mechanism to collision check during ik resampling (for torso, etc.)

### DIFF
--- a/cram_3d_world/cram_urdf_projection/src/low-level.lisp
+++ b/cram_3d_world/cram_urdf_projection/src/low-level.lisp
@@ -807,7 +807,7 @@ with the object, calculates similar angle around Y axis and applies the rotation
                                   ?torso-link ?left-ee-frame ?left-arm-joints
                                   ?torso-joint ?lower-limit ?upper-limit
                                   :collision-check-function #'perform-collision-check
-                                  :collision-check-arguments (list collision-mode left-tcp-pose right-tcp-pose)))
+                                  :collision-check-arguments `(,collision-mode ,left-tcp-pose ,right-tcp-pose)))
       (multiple-value-bind (right-ik right-torso-angle)
           (let ((ik::*ik-service-name*
                   (if (string-equal (symbol-name ?robot) "PR2")

--- a/cram_external_interfaces/cram_ik_interface/cram-ik-interface.asd
+++ b/cram_external_interfaces/cram_ik_interface/cram-ik-interface.asd
@@ -36,7 +36,9 @@
                cl-transforms-stamped
                cram-tf
                moveit_msgs-msg
-               moveit_msgs-srv)
+               moveit_msgs-srv
+               cram-bullet-reasoning
+               cram-language)
   :components
   ((:module "src"
     :components

--- a/cram_external_interfaces/cram_ik_interface/cram-ik-interface.asd
+++ b/cram_external_interfaces/cram_ik_interface/cram-ik-interface.asd
@@ -37,7 +37,7 @@
                cram-tf
                moveit_msgs-msg
                moveit_msgs-srv
-               cram-bullet-reasoning
+               cram-common-failures
                cram-language)
   :components
   ((:module "src"

--- a/cram_external_interfaces/cram_ik_interface/package.xml
+++ b/cram_external_interfaces/cram_ik_interface/package.xml
@@ -19,4 +19,6 @@
   <depend>cl_tf</depend>
   <depend>cram_tf</depend>
   <depend>moveit_msgs</depend>
+  <depend>cram_bullet_reasoning</depend>
+  <depend>cram_language</depend>
 </package>

--- a/cram_external_interfaces/cram_ik_interface/package.xml
+++ b/cram_external_interfaces/cram_ik_interface/package.xml
@@ -19,6 +19,6 @@
   <depend>cl_tf</depend>
   <depend>cram_tf</depend>
   <depend>moveit_msgs</depend>
-  <depend>cram_bullet_reasoning</depend>
+  <depend>cram_common_failures</depend>
   <depend>cram_language</depend>
 </package>

--- a/cram_external_interfaces/cram_ik_interface/src/ik.lisp
+++ b/cram_external_interfaces/cram_ik_interface/src/ik.lisp
@@ -129,63 +129,64 @@
                                                             current-value lower-limit upper-limit
                                                             &key collision-check-function
                                                             collision-check-arguments)
-  (let* ((world btr:*current-bullet-world*)
-         (world-state (btr::get-state world)))
-    (labels ((call-ik-service-inner (cartesian-pose
-                                     &key test-value current-value)
-               (let ((ik-solution-msg
-                       (call-ik-service
-                        cartesian-pose base-link end-effector-link seed-state-msg)))
-                 (if ik-solution-msg
-                     (cpl:with-failure-handling
-                         ((common-fail:manipulation-goal-not-reached (e)
-                            (declare (ignore e))
-                            (btr::restore-world-state world-state world)
-                            (call-ik-service-inner-with-next-solution cartesian-pose
-                                                                      :test-value test-value
-                                                                      :current-value current-value)))
-                       (apply collision-check-function collision-check-arguments)
-                       (values ik-solution-msg
-                               (or test-value current-value)))
-                     (when (or (not test-value) (> test-value lower-limit))
-                       ;; When we have no ik solution and have a valid test value to try,
-                       ;; use it to resample.
-                       (call-ik-service-inner-with-next-solution cartesian-pose
-                                                                 :test-value test-value
-                                                                 :current-value current-value)))))
-             (call-ik-service-inner-with-next-solution (cartesian-pose
-                                                        &key test-value current-value)
-               (let* ((next-test-value
-                        (if test-value
-                            (max lower-limit (- test-value resampling-step))
-                            upper-limit))
-                      (offset
-                        (if test-value
-                            (- test-value current-value)
-                            0))
-                      (next-offset
-                        (- next-test-value current-value))
-                      (pseudo-pose
-                        (cram-tf:translate-pose
-                         cartesian-pose
-                         (ecase resampling-axis
-                           (:x :x-offset)
-                           (:y :y-offset)
-                           (:z :z-offset))
-                         (- offset next-offset))))
-                 (call-ik-service-inner
-                  pseudo-pose
-                  :test-value next-test-value
-                  :current-value current-value))))
-      
-      (let ((old-debug-lvl (roslisp:debug-level nil)))
-        (unwind-protect
-             (progn
-               (roslisp:set-debug-level nil 9)
+  "Calls the IK service to achieve the specified `cartesian-pose' achieved by manipulating the
+joints from `base-link' to `end-effector-link'. A collision check is performed using the provided
+`collision-check-function' after obtaining a possible solution. The `collision-check-function' is
+invoked with the arguments provided in `collision-check-arguments' as a list. The function is
+expected to throw the `common-fail:manipulation-goal-not-reached' error when a collision occurs"
+
+  (labels ((call-ik-service-inner (cartesian-pose
+                                   &key test-value current-value)
+             (let ((ik-solution-msg
+                     (call-ik-service
+                      cartesian-pose base-link end-effector-link seed-state-msg)))
+               (if ik-solution-msg
+                   (cpl:with-failure-handling
+                       ((common-fail:manipulation-goal-not-reached (e)
+                          (declare (ignore e))
+                          (call-ik-service-inner-with-next-solution cartesian-pose
+                                                                    :test-value test-value
+                                                                    :current-value current-value)))
+                     (apply collision-check-function collision-check-arguments)
+                     (values ik-solution-msg
+                             (or test-value current-value)))
+                   (when (or (not test-value) (> test-value lower-limit))
+                     ;; When we have no ik solution and have a valid test value to try,
+                     ;; use it to resample.
+                     (call-ik-service-inner-with-next-solution cartesian-pose
+                                                               :test-value test-value
+                                                               :current-value current-value)))))
+           (call-ik-service-inner-with-next-solution (cartesian-pose
+                                                      &key test-value current-value)
+             (let* ((next-test-value
+                      (if test-value
+                          (max lower-limit (- test-value resampling-step))
+                          upper-limit))
+                    (offset
+                      (if test-value
+                          (- test-value current-value)
+                          0))
+                    (next-offset
+                      (- next-test-value current-value))
+                    (pseudo-pose
+                      (cram-tf:translate-pose
+                       cartesian-pose
+                       (ecase resampling-axis
+                         (:x :x-offset)
+                         (:y :y-offset)
+                         (:z :z-offset))
+                       (- offset next-offset))))
                (call-ik-service-inner
-                cartesian-pose
-                :test-value nil
-                :current-value current-value))
-          (progn
-            (btr::restore-world-state world-state world)
-            (roslisp:set-debug-level nil old-debug-lvl)))))))
+                pseudo-pose
+                :test-value next-test-value
+                :current-value current-value))))
+    
+    (let ((old-debug-lvl (roslisp:debug-level nil)))
+      (unwind-protect
+           (progn
+             (roslisp:set-debug-level nil 9)
+             (call-ik-service-inner
+              cartesian-pose
+              :test-value nil
+              :current-value current-value))
+        (roslisp:set-debug-level nil old-debug-lvl)))))

--- a/cram_external_interfaces/cram_ik_interface/src/ik.lisp
+++ b/cram_external_interfaces/cram_ik_interface/src/ik.lisp
@@ -120,3 +120,72 @@
               :test-value nil
               :current-value current-value))
         (roslisp:set-debug-level nil old-debug-lvl)))))
+
+
+(defun call-ik-service-with-resampling-and-collision-check (cartesian-pose
+                                                            base-link end-effector-link
+                                                            seed-state-msg
+                                                            resampling-step resampling-axis
+                                                            current-value lower-limit upper-limit
+                                                            &key collision-check-function
+                                                            collision-check-arguments)
+  (let* ((world btr:*current-bullet-world*)
+         (world-state (btr::get-state world)))
+    (labels ((call-ik-service-inner (cartesian-pose
+                                     &key test-value current-value)
+               (let ((ik-solution-msg
+                       (call-ik-service
+                        cartesian-pose base-link end-effector-link seed-state-msg)))
+                 (if ik-solution-msg
+                     (cpl:with-failure-handling
+                         ((common-fail:manipulation-goal-not-reached (e)
+                            (declare (ignore e))
+                            (btr::restore-world-state world-state world)
+                            (call-ik-service-inner-with-next-solution cartesian-pose
+                                                                      :test-value test-value
+                                                                      :current-value current-value)))
+                       (apply collision-check-function collision-check-arguments)
+                       (values ik-solution-msg
+                               (or test-value current-value)))
+                     (when (or (not test-value) (> test-value lower-limit))
+                       ;; When we have no ik solution and have a valid test value to try,
+                       ;; use it to resample.
+                       (call-ik-service-inner-with-next-solution cartesian-pose
+                                                                 :test-value test-value
+                                                                 :current-value current-value)))))
+             (call-ik-service-inner-with-next-solution (cartesian-pose
+                                                        &key test-value current-value)
+               (let* ((next-test-value
+                        (if test-value
+                            (max lower-limit (- test-value resampling-step))
+                            upper-limit))
+                      (offset
+                        (if test-value
+                            (- test-value current-value)
+                            0))
+                      (next-offset
+                        (- next-test-value current-value))
+                      (pseudo-pose
+                        (cram-tf:translate-pose
+                         cartesian-pose
+                         (ecase resampling-axis
+                           (:x :x-offset)
+                           (:y :y-offset)
+                           (:z :z-offset))
+                         (- offset next-offset))))
+                 (call-ik-service-inner
+                  pseudo-pose
+                  :test-value next-test-value
+                  :current-value current-value))))
+      
+      (let ((old-debug-lvl (roslisp:debug-level nil)))
+        (unwind-protect
+             (progn
+               (roslisp:set-debug-level nil 9)
+               (call-ik-service-inner
+                cartesian-pose
+                :test-value nil
+                :current-value current-value))
+          (progn
+            (btr::restore-world-state world-state world)
+            (roslisp:set-debug-level nil old-debug-lvl)))))))

--- a/cram_external_interfaces/cram_ik_interface/src/package.lisp
+++ b/cram_external_interfaces/cram_ik_interface/src/package.lisp
@@ -32,4 +32,6 @@
   (:use #:common-lisp)
   (:export
    ;; ik
-   #:call-ik-service #:call-ik-service-with-resampling))
+   #:call-ik-service
+   #:call-ik-service-with-resampling
+   #:call-ik-service-with-resampling-and-collision-check))


### PR DESCRIPTION
Adding a new ik service caller that does resampling as well as collision check. 
The new method works similar to the resampling version but now takes 2 more arguments
1. The collision check function
2. The collision check arguments as a list.

The appropriate collision check function can be passed down the chain and can be used to look for new solutions of ik during resampling. Any collision check error is only used to force the ik solver to sample the next solution and is not bubbled up.

Added the corresponding dependencies and exposed the API in the package, and using the said API in the urdf_projection package.