### PR TITLE
[common-fail]Unit test for different location solution

### DIFF
--- a/cram_common/cram_common_failures/cram-common-failures-tests.asd
+++ b/cram_common/cram_common_failures/cram-common-failures-tests.asd
@@ -31,36 +31,24 @@
   :license "BSD"
   
   :depends-on (lisp-unit
+               roslisp
+               cram-language
+               cram-prolog
+               cl-urdf
                cram-common-failures
                cram-bullet-reasoning
                cram-pr2-description
-               cram-robot-pose-gaussian-costmap
                cram-robot-interfaces
-               roslisp
-               cram-prolog
                cl-transforms
                cl-transforms-stamped
-               cl-urdf
-
-               cram-language
-               ;cram-executive
                cram-designators
-               ;cram-projection
-               ;cram-occasions-events
-               ;cram-utilities
-
                cram-object-knowledge
-               ;cl-bullet
-               ;cram-bullet-reasoning-belief-state
-               ;cram-bullet-reasoning-utilities
-
                cram-location-costmap
                cram-btr-visibility-costmap
                cram-btr-spatial-relations-costmap
                cram-occupancy-grid-costmap
-
-               
-               )
+               cram-robot-pose-gaussian-costmap)
+  
   :components
   ((:module "tests"
     :components

--- a/cram_common/cram_common_failures/cram-common-failures-tests.asd
+++ b/cram_common/cram_common_failures/cram-common-failures-tests.asd
@@ -1,19 +1,19 @@
-;;; Copyright (c) 2012, Amar Fayaz <amar@uni-bremen.de>
+;;; Copyright (c) 2020, Amar Fayaz <amar@uni-bremen.de>
 ;;; All rights reserved.
-;;; 
+;;;
 ;;; Redistribution and use in source and binary forms, with or without
 ;;; modification, are permitted provided that the following conditions are met:
-;;; 
+;;;
 ;;;     * Redistributions of source code must retain the above copyright
 ;;;       notice, this list of conditions and the following disclaimer.
 ;;;     * Redistributions in binary form must reproduce the above copyright
 ;;;       notice, this list of conditions and the following disclaimer in the
 ;;;       documentation and/or other materials provided with the distribution.
 ;;;     * Neither the name of the Intelligent Autonomous Systems Group/
-;;;       Technische Universitaet Muenchen nor the names of its contributors 
-;;;       may be used to endorse or promote products derived from this software 
+;;;       Technische Universitaet Muenchen nor the names of its contributors
+;;;       may be used to endorse or promote products derived from this software
 ;;;       without specific prior written permission.
-;;; 
+;;;
 ;;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 ;;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 ;;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -29,7 +29,7 @@
 (defsystem cram-common-failures-tests
   :author "Amar Fayaz"
   :license "BSD"
-  
+
   :depends-on (lisp-unit
                roslisp
                cram-language
@@ -48,7 +48,7 @@
                cram-btr-spatial-relations-costmap
                cram-occupancy-grid-costmap
                cram-robot-pose-gaussian-costmap)
-  
+
   :components
   ((:module "tests"
     :components

--- a/cram_common/cram_common_failures/cram-common-failures-tests.asd
+++ b/cram_common/cram_common_failures/cram-common-failures-tests.asd
@@ -1,0 +1,68 @@
+;;; Copyright (c) 2012, Amar Fayaz <amar@uni-bremen.de>
+;;; All rights reserved.
+;;; 
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions are met:
+;;; 
+;;;     * Redistributions of source code must retain the above copyright
+;;;       notice, this list of conditions and the following disclaimer.
+;;;     * Redistributions in binary form must reproduce the above copyright
+;;;       notice, this list of conditions and the following disclaimer in the
+;;;       documentation and/or other materials provided with the distribution.
+;;;     * Neither the name of the Intelligent Autonomous Systems Group/
+;;;       Technische Universitaet Muenchen nor the names of its contributors 
+;;;       may be used to endorse or promote products derived from this software 
+;;;       without specific prior written permission.
+;;; 
+;;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+;;; LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+;;; CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+;;; SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+;;; CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+;;; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+;;; POSSIBILITY OF SUCH DAMAGE.
+
+(defsystem cram-common-failures-tests
+  :author "Amar Fayaz"
+  :license "BSD"
+  
+  :depends-on (lisp-unit
+               cram-common-failures
+               cram-bullet-reasoning
+               cram-pr2-description
+               cram-robot-pose-gaussian-costmap
+               cram-robot-interfaces
+               roslisp
+               cram-prolog
+               cl-transforms
+               cl-transforms-stamped
+               cl-urdf
+
+               cram-language
+               ;cram-executive
+               cram-designators
+               ;cram-projection
+               ;cram-occasions-events
+               ;cram-utilities
+
+               cram-object-knowledge
+               ;cl-bullet
+               ;cram-bullet-reasoning-belief-state
+               ;cram-bullet-reasoning-utilities
+
+               cram-location-costmap
+               cram-btr-visibility-costmap
+               cram-btr-spatial-relations-costmap
+               cram-occupancy-grid-costmap
+
+               
+               )
+  :components
+  ((:module "tests"
+    :components
+    ((:file "package")
+     (:file "different-location-solution-test" :depends-on ("package"))))))

--- a/cram_common/cram_common_failures/src/failure-handling-strategies.lisp
+++ b/cram_common/cram_common_failures/src/failure-handling-strategies.lisp
@@ -30,8 +30,7 @@
 (in-package :common-fail)
 
 (defparameter *default-distance-threshold* 0.05
-  "Distance threshold used as a default for identifying unique
-poses")
+  "Distance threshold used as a default for identifying unique poses")
 
 (defmacro retry-with-designator-solutions (iterator-desig
                                            retries
@@ -82,7 +81,8 @@ after each iteration of the retry."
   `(progn
      (roslisp:ros-warn ,warning-namespace "~a" ,error-object-or-string)
      (cpl:do-retry ,retries
-       (let ((next-solution-element (cut:lazy-car (cut:lazy-cdr ,iterator-list))))
+       (let ((next-solution-element
+               (cut:lazy-car (cut:lazy-cdr ,iterator-list))))
          (if next-solution-element
              (progn
                (roslisp:ros-warn ,warning-namespace "Retrying.~%")
@@ -95,7 +95,9 @@ after each iteration of the retry."
        (cpl:fail ,rethrow-failure))))
 
 (defun next-different-location-solution (designator
-                                         &optional (distance-threshold *default-distance-threshold*))
+                                         &optional
+                                           (distance-threshold
+                                            *default-distance-threshold*))
   "Returns a new designator solution that is at a different place than
   the current solution of `designator'."
   (declare (type desig:location-designator designator))
@@ -110,7 +112,8 @@ after each iteration of the retry."
                                                   error-object-or-string
                                                   warning-namespace
                                                   reset-designators
-                                                  (distance-threshold *default-distance-threshold*)
+                                                  (distance-threshold
+                                                   *default-distance-threshold*)
                                                   (rethrow-failure NIL))
                                                &body body)
   "Macro that iterates through different solutions of the specified

--- a/cram_common/cram_common_failures/src/failure-handling-strategies.lisp
+++ b/cram_common/cram_common_failures/src/failure-handling-strategies.lisp
@@ -29,6 +29,10 @@
 
 (in-package :common-fail)
 
+(defparameter *default-distance-threshold* 0.05
+  "Distance threshold used as a default for identifying unique
+poses")
+
 (defmacro retry-with-designator-solutions (iterator-desig
                                            retries
                                            (&key
@@ -91,7 +95,7 @@ after each iteration of the retry."
        (cpl:fail ,rethrow-failure))))
 
 (defun next-different-location-solution (designator
-                                         &optional (distance-threshold 0.05))
+                                         &optional (distance-threshold *default-distance-threshold*))
   "Returns a new designator solution that is at a different place than
   the current solution of `designator'."
   (declare (type desig:location-designator designator))
@@ -106,7 +110,7 @@ after each iteration of the retry."
                                                   error-object-or-string
                                                   warning-namespace
                                                   reset-designators
-                                                  (distance-threshold 0.05)
+                                                  (distance-threshold *default-distance-threshold*)
                                                   (rethrow-failure NIL))
                                                &body body)
   "Macro that iterates through different solutions of the specified

--- a/cram_common/cram_common_failures/tests/different-location-solution-test.lisp
+++ b/cram_common/cram_common_failures/tests/different-location-solution-test.lisp
@@ -38,9 +38,8 @@
 (defparameter *test-location* (let ((?target *target-location*))
                                 (desig:a location
                                          (reachable-for pr2)
-                                         (location (desig:a
-                                                    location
-                                                    (pose ?target))))))
+                                         (location (desig:a location
+                                                            (pose ?target))))))
 
 (defun setup-world ()
   (setf rob-int:*robot-urdf*
@@ -50,7 +49,6 @@
          (rob-int:robot ?robot)
          (assert (btr:object ?world :urdf ?robot ((0 0 0) (0 0 0 1))
                              :urdf ,rob-int:*robot-urdf*))))
-  (clrhash (btr::get-updated-attachments))
   (btr:detach-all-objects (btr:get-robot-object)))
 
 
@@ -85,14 +83,15 @@
                                *test-location*
                                robot-location-retries
                                (:error-object-or-string e
-                                :warning-namespace (fd-plans search-for-object)
-                                :rethrow-failure 'common-fail:object-nowhere-to-be-found)
+                                :warning-namespace
+                                (fd-plans search-for-object)
+                                :rethrow-failure
+                                'common-fail:object-nowhere-to-be-found)
                              (push
                               (desig:reference *test-location*)
                               location-output))))
-
-
                       (cpl:fail 'common-fail:looking-high-level-failure))))
+
     (assert-true  (eq 8 (length location-output)))
     (maplist (lambda (pose-list)
                (when (>= (length pose-list) 2)

--- a/cram_common/cram_common_failures/tests/different-location-solution-test.lisp
+++ b/cram_common/cram_common_failures/tests/different-location-solution-test.lisp
@@ -1,5 +1,5 @@
 ;;;
-;;; Copyright (c) 2019, Amar Fayaz <amar@uni-bremen.de>
+;;; Copyright (c) 2020, Amar Fayaz <amar@uni-bremen.de>
 ;;; All rights reserved.
 ;;;
 ;;; Redistribution and use in source and binary forms, with or without
@@ -29,11 +29,11 @@
 
 (in-package :cram-common-failures-tests)
 
-(defparameter *target-location* (cl-tf:make-pose-stamped
+(defparameter *target-location* (cl-transforms-stamped:make-pose-stamped
                                  "map"
                                  0.0
-                                 (cl-tf:make-3d-vector 0 1 0)
-                                 (cl-tf:make-quaternion 0 0 0 1)))
+                                 (cl-transforms:make-3d-vector 0 1 0)
+                                 (cl-transforms:make-quaternion 0 0 0 1)))
 
 (defparameter *test-location* (let ((?target *target-location*))
                                 (desig:a location
@@ -62,11 +62,12 @@
   (setup-world)
   (let ((first-location (desig:reference *test-location*))
         (new-location (desig:reference
-                       (common-fail:next-different-location-solution *test-location*))))
+                       (common-fail:next-different-location-solution
+                        *test-location*))))
     (assert-true (< cram-common-failures::*default-distance-threshold*
-                    (cl-tf:v-dist
-                     (cl-tf:origin first-location)
-                     (cl-tf:origin new-location))))))
+                    (cl-transforms:v-dist
+                     (cl-transforms:origin first-location)
+                     (cl-transforms:origin new-location))))))
 
 
 (define-test retry-with-diff-loc-designator-test
@@ -85,16 +86,19 @@
                                robot-location-retries
                                (:error-object-or-string e
                                 :warning-namespace (fd-plans search-for-object)
-                                :rethrow-failure 'common-fail:object-nowhere-to-be-found) 
-                             (push (desig:reference *test-location*) location-output))))
+                                :rethrow-failure 'common-fail:object-nowhere-to-be-found)
+                             (push
+                              (desig:reference *test-location*)
+                              location-output))))
 
 
                       (cpl:fail 'common-fail:looking-high-level-failure))))
     (assert-true  (eq 8 (length location-output)))
     (maplist (lambda (pose-list)
                (when (>= (length pose-list) 2)
-                 (assert-true (< cram-common-failures::*default-distance-threshold*
-                                 (cl-tf:v-dist
-                                  (cl-tf:origin (first pose-list))
-                                  (cl-tf:origin (second pose-list)))))))
+                 (assert-true
+                  (< cram-common-failures::*default-distance-threshold*
+                     (cl-transforms:v-dist
+                      (cl-transforms:origin (first pose-list))
+                      (cl-transforms:origin (second pose-list)))))))
              location-output)))

--- a/cram_common/cram_common_failures/tests/different-location-solution-test.lisp
+++ b/cram_common/cram_common_failures/tests/different-location-solution-test.lisp
@@ -1,0 +1,100 @@
+;;;
+;;; Copyright (c) 2019, Amar Fayaz <amar@uni-bremen.de>
+;;; All rights reserved.
+;;;
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions are met:
+;;;
+;;;     * Redistributions of source code must retain the above copyright
+;;;       notice, this list of conditions and the following disclaimer.
+;;;     * Redistributions in binary form must reproduce the above copyright
+;;;       notice, this list of conditions and the following disclaimer in the
+;;;       documentation and/or other materials provided with the distribution.
+;;;     * Neither the name of the Institute for Artificial Intelligence/
+;;;       Universitaet Bremen nor the names of its contributors may be used to
+;;;       endorse or promote products derived from this software without
+;;;       specific prior written permission.
+;;;
+;;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+;;; LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+;;; CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+;;; SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+;;; CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+;;; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+;;; POSSIBILITY OF SUCH DAMAGE.
+
+(in-package :cram-common-failures-tests)
+
+(defparameter *target-location* (cl-tf:make-pose-stamped
+                                 "map"
+                                 0.0
+                                 (cl-tf:make-3d-vector 0 1 0)
+                                 (cl-tf:make-quaternion 0 0 0 1)))
+
+(defparameter *test-location* (let ((?target *target-location*))
+                                (desig:a location
+                                         (reachable-for pr2)
+                                         (location (desig:a
+                                                    location
+                                                    (pose ?target))))))
+
+(defun setup-world ()
+  (setf rob-int:*robot-urdf*
+        (cl-urdf:parse-urdf (roslisp:get-param "robot_description")))
+  (prolog:prolog
+   `(and (btr:bullet-world ?world)
+         (rob-int:robot ?robot)
+         (assert (btr:object ?world :urdf ?robot ((0 0 0) (0 0 0 1))
+                             :urdf ,rob-int:*robot-urdf*))))
+  (clrhash (btr::get-updated-attachments))
+  (btr:detach-all-objects (btr:get-robot-object)))
+
+
+;; roslaunch cram_pr2_pick_place_demo sandbox.launch
+
+(define-test next-different-location-solution-test
+  (unless (eq roslisp::*node-status* :RUNNING)
+    (roslisp-utilities:startup-ros))
+  (setup-world)
+  (let ((first-location (desig:reference *test-location*))
+        (new-location (desig:reference
+                       (common-fail:next-different-location-solution *test-location*))))
+    (assert-true (< cram-common-failures::*default-distance-threshold*
+                    (cl-tf:v-dist
+                     (cl-tf:origin first-location)
+                     (cl-tf:origin new-location))))))
+
+
+(define-test retry-with-diff-loc-designator-test
+  (unless (eq roslisp::*node-status* :RUNNING)
+    (roslisp-utilities:startup-ros))
+  (setup-world)
+  (let ((location-output))
+    (assert-error 'common-fail:object-nowhere-to-be-found
+                  (cpl:with-retry-counters ((robot-location-retries 8))
+                    (cpl:with-failure-handling
+                        (((or common-fail:navigation-goal-in-collision
+                              common-fail:looking-high-level-failure
+                              common-fail:perception-low-level-failure) (e)
+                           (common-fail:retry-with-loc-designator-solutions
+                               *test-location*
+                               robot-location-retries
+                               (:error-object-or-string e
+                                :warning-namespace (fd-plans search-for-object)
+                                :rethrow-failure 'common-fail:object-nowhere-to-be-found) 
+                             (push (desig:reference *test-location*) location-output))))
+
+
+                      (cpl:fail 'common-fail:looking-high-level-failure))))
+    (assert-true  (eq 8 (length location-output)))
+    (maplist (lambda (pose-list)
+               (when (>= (length pose-list) 2)
+                 (assert-true (< cram-common-failures::*default-distance-threshold*
+                                 (cl-tf:v-dist
+                                  (cl-tf:origin (first pose-list))
+                                  (cl-tf:origin (second pose-list)))))))
+             location-output)))

--- a/cram_common/cram_common_failures/tests/package.lisp
+++ b/cram_common/cram_common_failures/tests/package.lisp
@@ -1,0 +1,34 @@
+;;; Copyright (c) 2012, Amar Fayaz <amar@uni-bremen.de>
+;;; All rights reserved.
+;;; 
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions are met:
+;;; 
+;;;     * Redistributions of source code must retain the above copyright
+;;;       notice, this list of conditions and the following disclaimer.
+;;;     * Redistributions in binary form must reproduce the above copyright
+;;;       notice, this list of conditions and the following disclaimer in the
+;;;       documentation and/or other materials provided with the distribution.
+;;;     * Neither the name of the Intelligent Autonomous Systems Group/
+;;;       Technische Universitaet Muenchen nor the names of its contributors 
+;;;       may be used to endorse or promote products derived from this software 
+;;;       without specific prior written permission.
+;;; 
+;;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+;;; LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+;;; CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+;;; SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+;;; CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+;;; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+;;; POSSIBILITY OF SUCH DAMAGE.
+
+(in-package :cl-user)
+
+(defpackage cram-common-failures-tests
+  (:nicknames :common-fail-tests)
+  (:use #:common-lisp #:cram-common-failures #:lisp-unit)
+  (:export))

--- a/cram_common/cram_common_failures/tests/package.lisp
+++ b/cram_common/cram_common_failures/tests/package.lisp
@@ -1,4 +1,4 @@
-;;; Copyright (c) 2012, Amar Fayaz <amar@uni-bremen.de>
+;;; Copyright (c) 2020, Amar Fayaz <amar@uni-bremen.de>
 ;;; All rights reserved.
 ;;; 
 ;;; Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
* Created unit tests for common-fail:next-different-location-solution used alone and along with common-fail:retry-with-loc-designator solutions. 
* Created the asd system.
* Parameterized the default distance filter threshold to reuse in testing.


Note: I wasn't able to find any issues of the robot getting stuck in the same place. Please check if I"m missing something here.