### PR TITLE
Fix dual-arm attachments: loose stuff seems to be buggy

### DIFF
--- a/cram_3d_world/cram_bullet_reasoning/src/robot-model.lisp
+++ b/cram_3d_world/cram_bullet_reasoning/src/robot-model.lisp
@@ -368,9 +368,11 @@ was updated by checking if `link' was already updated. The already
 updated links are saved under the attachment name in `updated-attachments'.
 If all links of an attachment were updated the entry under the attachment
 name in `updated-attachments' gets deleted."
-    (let ((links-attached-to (mapcar #'attachment-link (car (cdr attachment))))
+    (let ((links-to-update (mapcar #'attachment-link 
+                                   (remove-if #'attachment-loose
+                                              (car (cdr attachment)))))
           (ret T))
-      (when (and link (member (cl-urdf:name link) links-attached-to :test #'string-equal))
+      (when (and link (member (cl-urdf:name link) links-to-update :test #'string-equal))
         (if (gethash (car attachment) updated-attachments)
             (setf (gethash (car attachment) updated-attachments)
                   (push (cl-urdf:name link) (gethash (car attachment) updated-attachments)))
@@ -380,11 +382,11 @@ name in `updated-attachments' gets deleted."
                   NIL))
         ;; checks if the list of links in attachment and the already visited links are equal
         (when (equal
-               (length links-attached-to)
+               (length links-to-update)
                (length
                 (intersection
                  (gethash (car attachment) updated-attachments)
-                 links-attached-to :test #'string-equal)))
+                 links-to-update :test #'string-equal)))
           (remhash (car attachment) updated-attachments))
         (return-from updated-link-in-attachment ret)))))
 

--- a/cram_3d_world/cram_bullet_reasoning_belief_state/src/event-handlers.lisp
+++ b/cram_3d_world/cram_bullet_reasoning_belief_state/src/event-handlers.lisp
@@ -132,12 +132,9 @@ If there is no other method with 1 as qualifier, this method will be executed al
           (mapc (lambda (attached-link grasp)
                   ;; detach and attach again with loose attachment
                   (btr:detach-object robot-object btr-object :link attached-link)
-                  ;; TODO: These loose attachments seem buggy,
-                  ;; so just removing completely...
-                  ;; (btr:attach-object robot-object btr-object :link attached-link
-                  ;;                                            :loose t
-                  ;;                                            :grasp grasp)
-                  )
+                  (btr:attach-object robot-object btr-object :link attached-link
+                                                             :loose t
+                                                             :grasp grasp))
                 links grasps)))
       ;; attach
       (btr:attach-object robot-object btr-object :link link :loose nil :grasp grasp))))


### PR DESCRIPTION
To check if the pose of an attached object was already updated, updated-link-in-attachment saves which links are attached and which were already updated by traversing the robots link tree. Since the object can be attached to both arms and there are motions which allow to move independently from each arm, it is not known if the pose of the attached object was already updated by the other arm. Because updated-link-in-attachment cannot know, if motions were executed for both links/arms the object is attached to, only links which are not loosely attached are updated. In particular, in the below code this resulted in checking if the traversed links for an attachment match with its list of links establishing a non loose attachment. 

Trello: https://trello.com/c/75sIYAGF/291-fix-dual-arm-attachments-loose-stuff-seems-to-be-buggy