### PR TITLE
btr:robot-attached-objects-in-collision has a bug when floor is in collision

### DIFF
--- a/cram_3d_world/cram_bullet_reasoning/src/robot-model-utils.lisp
+++ b/cram_3d_world/cram_bullet_reasoning/src/robot-model-utils.lisp
@@ -199,11 +199,18 @@ or other objects to which current object is attached."
   (some #'identity
         (mapcar (lambda (attachment)
                   ;; remove if object has attachments, which are then colliding
-                  (remove-if #'attached-objects
-                             ;; remove if robot is colliding
-                             (remove (get-robot-object)
-                                     (find-objects-in-contact
-                                      *current-bullet-world*
-                                      (object *current-bullet-world*
-                                              (car attachment))))))
+                  (let ((colliding-objects (remove (get-robot-object)
+                                                   (find-objects-in-contact
+                                                    *current-bullet-world*
+                                                    (object *current-bullet-world*
+                                                            (car attachment))))))
+                    ;; remove colliding object, if it is attached with
+                    ;; the same object the robot is attached with
+                    (remove-if (lambda (object)
+                                 (when (or (typep object 'btr:item)
+                                           (typep object 'btr:robot-object))
+                                   (find (car attachment)
+                                         (btr:attached-objects object)
+                                         :key #'car)))
+                               colliding-objects)))   
                 (attached-objects (get-robot-object)))))

--- a/cram_3d_world/cram_bullet_reasoning/tests/objects-tests.lisp
+++ b/cram_3d_world/cram_bullet_reasoning/tests/objects-tests.lisp
@@ -50,6 +50,19 @@
   (equal (pose->list pose)
          (pose->list other-pose)))
 
+(defun spawn-robot ()
+  (setf rob-int:*robot-urdf*
+        (cl-urdf:parse-urdf
+         (roslisp:get-param "robot_description")))
+  (prolog:prolog
+   `(and (btr:bullet-world ?world)
+         (rob-int:robot ?robot)
+         (assert (btr:object ?world :urdf ?robot ((0 0 0) (0 0 0 1))
+                             :urdf ,rob-int::*robot-urdf*))
+         (assert (btr:joint-state ?world ?robot (("torso_lift_joint"
+                                                  0.15d0))))))
+  (btr:detach-all-objects (btr:get-robot-object)))
+
 
 (define-test create-static-collision-information-works
   ;; Tests if the collision information is properly saved and if it

--- a/cram_3d_world/cram_bullet_reasoning/tests/robot-model-utils-tests.lisp
+++ b/cram_3d_world/cram_bullet_reasoning/tests/robot-model-utils-tests.lisp
@@ -92,62 +92,60 @@
   (clean-environment '(:plate-1)))
 
 (define-test robot-attached-objects-in-collision-positive-environment-collisions
-  (when (fboundp 'demo::init-projection)
-    (demo::init-projection)
-    (setup-world)
-    (btr-utils:kill-all-objects)
-    (btr:detach-all-objects (btr:get-robot-object))
-    (btr:detach-all-objects (btr:get-environment-object))
-    ;; spawn basket which is in collision with the environment
-    (btr:add-object btr:*current-bullet-world* :basket :basket-1
-                    '((1.2 0 0.8) (0.0 0 0 1.0))
-                    :length 0.2 :width 0.2 :height 0.2)
-    ;; attach basket to robot 
-    (btr:attach-object (btr:get-robot-object)
-                       (btr:object btr:*current-bullet-world* :basket-1)
-                       :link "r_wrist_roll_link" :loose nil :grasp :front)
-    ;; check for collision 
-    (assert-equal '(:ENVIRONMENT) 
-                  (mapcar #'btr:name (btr::robot-attached-objects-in-collision)))
-    ;; spawn plate on sink area surface ...
-    (btr-utils:spawn-object :plate-1 :plate :pose '((1.5 0.5 0.9) (0.0 0 0 1.0)))
-    ;; ... and attach it to the environment 
-    (btr:attach-object (btr:get-environment-object)
-                       (btr:object btr:*current-bullet-world*
-                                   :plate-1)
-                       :link "sink_area_surface")
-    ;; and check for collisions again 
-    (assert-equal '(:ENVIRONMENT) 
-                  (mapcar #'btr:name (btr::robot-attached-objects-in-collision)))
-    (clean-environment '(:basket-1 :plate-1))))
+  (setup-world)
+  (spawn-robot)
+  (btr-utils:kill-all-objects)
+  (btr:detach-all-objects (btr:get-robot-object))
+  (btr:detach-all-objects (btr:get-environment-object))
+  ;; spawn basket which is in collision with the environment
+  (btr:add-object btr:*current-bullet-world* :basket :basket-1
+                  '((1.2 0 0.8) (0.0 0 0 1.0))
+                                                     :length 0.2 :width 0.2 :height 0.2)
+  ;; attach basket to robot 
+  (btr:attach-object (btr:get-robot-object)
+                     (btr:object btr:*current-bullet-world* :basket-1)
+                     :link "r_wrist_roll_link" :loose nil :grasp :front)
+  ;; check for collision 
+  (assert-equal '(:ENVIRONMENT) 
+                (mapcar #'btr:name (btr::robot-attached-objects-in-collision)))
+  ;; spawn plate on sink area surface ...
+  (btr-utils:spawn-object :plate-1 :plate :pose '((1.5 0.5 0.9) (0.0 0 0 1.0)))
+  ;; ... and attach it to the environment 
+  (btr:attach-object (btr:get-environment-object)
+                     (btr:object btr:*current-bullet-world*
+                                 :plate-1)
+                     :link "sink_area_surface")
+  ;; and check for collisions again 
+  (assert-equal '(:ENVIRONMENT) 
+                (mapcar #'btr:name (btr::robot-attached-objects-in-collision)))
+  (clean-environment '(:basket-1 :plate-1)))
 
 (define-test robot-attached-objects-in-collision-negative-environment-collisions
-  (when (fboundp 'demo::init-projection)
-    (demo::init-projection)
-    (setup-world)
-    (btr-utils:kill-all-objects)
-    (btr:detach-all-objects (btr:get-robot-object))
-    (btr:detach-all-objects (btr:get-environment-object))
-    ;; spawn basket which is in collision with the environment
-    (btr:add-object btr:*current-bullet-world* :basket :basket-1
-                    '((1.2 0 0.8) (0.0 0 0 1.0))
-                     :length 0.2 :width 0.2 :height 0.2)
-    ;; attach basket to robot 
-    (btr:attach-object (btr:get-robot-object)
-                       (btr:object btr:*current-bullet-world* :basket-1)
-                       :link "r_wrist_roll_link" :loose nil :grasp :front)
-    ;; spawn plate on sink area surface ...
-    (btr-utils:spawn-object :plate-1 :plate :pose '((1.5 0.5 0.9) (0.0 0 0 1.0)))
-    ;; ... and attach it to the environment 
-    (btr:attach-object (btr:get-environment-object)
-                       (btr:object btr:*current-bullet-world*
-                                   :plate-1)
-                       :link "sink_area_surface")
-    ;; attach basket to the environment 
-    (btr:attach-object (btr:get-environment-object)
-                       (btr:object btr:*current-bullet-world*
-                                   :basket-1)
-                       :link "sink_area_surface")
-    ;; check collisions again 
-    (assert-false (mapcar #'btr:name (btr::robot-attached-objects-in-collision)))
-    (clean-environment '(:basket-1 :plate-1))))
+  (setup-world)
+  (spawn-robot)
+  (btr-utils:kill-all-objects)
+  (btr:detach-all-objects (btr:get-robot-object))
+  (btr:detach-all-objects (btr:get-environment-object))
+  ;; spawn basket which is in collision with the environment
+  (btr:add-object btr:*current-bullet-world* :basket :basket-1
+                  '((1.2 0 0.8) (0.0 0 0 1.0))
+                                                     :length 0.2 :width 0.2 :height 0.2)
+  ;; attach basket to robot 
+  (btr:attach-object (btr:get-robot-object)
+                     (btr:object btr:*current-bullet-world* :basket-1)
+                     :link "r_wrist_roll_link" :loose nil :grasp :front)
+  ;; spawn plate on sink area surface ...
+  (btr-utils:spawn-object :plate-1 :plate :pose '((1.5 0.5 0.9) (0.0 0 0 1.0)))
+  ;; ... and attach it to the environment 
+  (btr:attach-object (btr:get-environment-object)
+                     (btr:object btr:*current-bullet-world*
+                                 :plate-1)
+                     :link "sink_area_surface")
+  ;; attach basket to the environment 
+  (btr:attach-object (btr:get-environment-object)
+                     (btr:object btr:*current-bullet-world*
+                                 :basket-1)
+                     :link "sink_area_surface")
+  ;; check collisions again 
+  (assert-false (mapcar #'btr:name (btr::robot-attached-objects-in-collision)))
+  (clean-environment '(:basket-1 :plate-1)))

--- a/cram_3d_world/cram_bullet_reasoning/tests/robot-model-utils-tests.lisp
+++ b/cram_3d_world/cram_bullet_reasoning/tests/robot-model-utils-tests.lisp
@@ -36,7 +36,7 @@
 
 (defun spawn-objects-with-same-pose (names)
   (mapcar (lambda (name)
-            (btr-utils:spawn-object name :mug :pose '((0 0 0) (0 0 0 1))))
+            (btr-utils:spawn-object name :mug :pose '((0 0 2.0) (0 0 0 1))))
           names))
 
 (define-test robot-attached-objects-in-collision-negative
@@ -75,3 +75,79 @@
                      :link "base_footprint")
   (assert-false (btr:robot-attached-objects-in-collision)) ;; -> no collision
   (clean-environment '(o oo)))
+
+(define-test robot-attached-objects-in-collision-positive-colliding-with-floor
+  (setup-world)
+  (btr-utils:kill-all-objects)
+  (btr:detach-all-objects (btr:get-robot-object))
+  (btr:detach-all-objects (btr:get-environment-object))
+  ;; spawn plate intersecting the floor
+  (btr-utils:spawn-object :plate-1 :plate :pose '((0.9 0 0.0) (0.7 0 0 0.7)) :mass 1.0)
+  ;; attach plate to the robot
+  (btr:attach-object (btr:get-robot-object)
+                     (btr:object btr:*current-bullet-world* :plate-1)
+                     :link "r_wrist_roll_link" :loose nil :grasp :front)
+  ;; check for collisions
+  (assert-equal '(:FLOOR) (mapcar #'btr:name (btr::robot-attached-objects-in-collision)))
+  (clean-environment '(:plate-1)))
+
+(define-test robot-attached-objects-in-collision-positive-environment-collisions
+  (when (fboundp 'demo::init-projection)
+    (demo::init-projection)
+    (setup-world)
+    (btr-utils:kill-all-objects)
+    (btr:detach-all-objects (btr:get-robot-object))
+    (btr:detach-all-objects (btr:get-environment-object))
+    ;; spawn basket which is in collision with the environment
+    (btr:add-object btr:*current-bullet-world* :basket :basket-1
+                    '((1.2 0 0.8) (0.0 0 0 1.0))
+                    :length 0.2 :width 0.2 :height 0.2)
+    ;; attach basket to robot 
+    (btr:attach-object (btr:get-robot-object)
+                       (btr:object btr:*current-bullet-world* :basket-1)
+                       :link "r_wrist_roll_link" :loose nil :grasp :front)
+    ;; check for collision 
+    (assert-equal '(:ENVIRONMENT) 
+                  (mapcar #'btr:name (btr::robot-attached-objects-in-collision)))
+    ;; spawn plate on sink area surface ...
+    (btr-utils:spawn-object :plate-1 :plate :pose '((1.5 0.5 0.9) (0.0 0 0 1.0)))
+    ;; ... and attach it to the environment 
+    (btr:attach-object (btr:get-environment-object)
+                       (btr:object btr:*current-bullet-world*
+                                   :plate-1)
+                       :link "sink_area_surface")
+    ;; and check for collisions again 
+    (assert-equal '(:ENVIRONMENT) 
+                  (mapcar #'btr:name (btr::robot-attached-objects-in-collision)))
+    (clean-environment '(:basket-1 :plate-1))))
+
+(define-test robot-attached-objects-in-collision-negative-environment-collisions
+  (when (fboundp 'demo::init-projection)
+    (demo::init-projection)
+    (setup-world)
+    (btr-utils:kill-all-objects)
+    (btr:detach-all-objects (btr:get-robot-object))
+    (btr:detach-all-objects (btr:get-environment-object))
+    ;; spawn basket which is in collision with the environment
+    (btr:add-object btr:*current-bullet-world* :basket :basket-1
+                    '((1.2 0 0.8) (0.0 0 0 1.0))
+                     :length 0.2 :width 0.2 :height 0.2)
+    ;; attach basket to robot 
+    (btr:attach-object (btr:get-robot-object)
+                       (btr:object btr:*current-bullet-world* :basket-1)
+                       :link "r_wrist_roll_link" :loose nil :grasp :front)
+    ;; spawn plate on sink area surface ...
+    (btr-utils:spawn-object :plate-1 :plate :pose '((1.5 0.5 0.9) (0.0 0 0 1.0)))
+    ;; ... and attach it to the environment 
+    (btr:attach-object (btr:get-environment-object)
+                       (btr:object btr:*current-bullet-world*
+                                   :plate-1)
+                       :link "sink_area_surface")
+    ;; attach basket to the environment 
+    (btr:attach-object (btr:get-environment-object)
+                       (btr:object btr:*current-bullet-world*
+                                   :basket-1)
+                       :link "sink_area_surface")
+    ;; check collisions again 
+    (assert-false (mapcar #'btr:name (btr::robot-attached-objects-in-collision)))
+    (clean-environment '(:basket-1 :plate-1))))


### PR DESCRIPTION
Fixed problems mentioned in [this](https://trello.com/c/re3uy1ez/267-btrrobot-attached-objects-in-collision-has-a-bug-when-floor-is-in-collision-removing-anything-that-has-attachments-is-incorrect) Trello Card. Added some tests which are executable with `(lisp-unit:run-tests :all :cram-bullet-reasoning-tests)` after loading the cram-pr2-pick-place package.