### PR TITLE
Collision Flag Bug With Attachments

### DIFF
--- a/cram_3d_world/cram_bullet_reasoning/cram-bullet-reasoning-tests.asd
+++ b/cram_3d_world/cram_bullet_reasoning/cram-bullet-reasoning-tests.asd
@@ -10,7 +10,7 @@
   :components ((:module "tests"
                 :components
                 ((:file "package")
-                 (:file "items-tests" :depends-on ("package"))
+                 (:file "items-tests" :depends-on ("package objects-tests"))
                  (:file "objects-tests" :depends-on ("package"))
                  (:file "robot-model-tests" :depends-on ("package"))
                  (:file "robot-model-utils-tests" :depends-on ("package" "robot-model-tests" "objects-tests"))

--- a/cram_3d_world/cram_bullet_reasoning/src/items.lisp
+++ b/cram_3d_world/cram_bullet_reasoning/src/items.lisp
@@ -147,22 +147,27 @@ unidirectional. See `attach-object' above."
     (return-from attach-object))
   (unless skip-removing-loose
     (remove-loose-attachment-for object))
-  (push (cons (name object)
-              (cons
-               (list (make-attachment :object (name object)
-                                      :attachment attachment-type))
-               ;; Since robot objects are not in the attached-objects
-               ;; list of items, this has to be copied manuelly:
-               (if (object-attached (get-robot-object) object)
-                   (get-collision-information object (get-robot-object))
-                   (create-static-collision-information object))))
-        (slot-value other-object 'attached-objects))
-  (push (cons (name other-object)
-              (cons
-               (list (make-attachment :object (name other-object)
-                                      :loose loose :attachment attachment-type))
-               (create-static-collision-information other-object)))
-        (slot-value object 'attached-objects)))
+  (let ((object-collision-information 
+          ;; Since robot objects are not in the attached-objects
+          ;; list of items, this has to be copied manuelly:
+          (if (object-attached (get-robot-object) object)
+              (get-collision-information object (get-robot-object))
+              (create-static-collision-information object)))
+        (other-object-collision-information 
+          (create-static-collision-information other-object)))
+    
+    (push (cons (name object)
+                (cons
+                 (list (make-attachment :object (name object)
+                                        :attachment attachment-type))
+                 object-collision-information))
+          (slot-value other-object 'attached-objects))
+    (push (cons (name other-object)
+                (cons
+                 (list (make-attachment :object (name other-object)
+                                        :loose loose :attachment attachment-type))
+                 other-object-collision-information))
+          (slot-value object 'attached-objects))))
 
 (defmethod attach-object ((other-objects list) (object item)
                           &key attachment-type loose)

--- a/cram_3d_world/cram_bullet_reasoning/src/objects.lisp
+++ b/cram_3d_world/cram_bullet_reasoning/src/objects.lisp
@@ -363,19 +363,27 @@ who is the parent of `object' in the attachment."
       (loop for body in (rigid-bodies object)
             collecting (make-collision-information
                         :rigid-body-name (name body)
-                        :flags (cond ((not (attached-objects object))
+                        :flags (cond (;; If the object does have no
+                                      ;; attached objects we take the
+                                      ;; current state of it.
+                                      (not (attached-objects object))
                                       (collision-flags body))
-                                     ((object-static-in-past-p object)
+                                     ;; If the object is attached with
+                                     ;; other objects we use the saved
+                                     ;; collision information from
+                                     ;; these objects. If the
+                                     ;; collision information of all
+                                     ;; these objects is static, this
+                                     ;; returns static too.
+                                     ((only-static-in-attachments-p object)
                                       '(:cf-static-object))
                                      (t
                                       NIL)))
-                        do (setf (collision-flags body) :cf-static-object))))
+            do (setf (collision-flags body) :cf-static-object))))
 
-(defun object-static-in-past-p (object)
-  "Returns if the `object's flags were `cf-static-object' at the
-beginning or if its flags were set to `cf-static-object', because
-it was attached to other objects. Returns T, if `object's flags were
-always `cf-static-object', else NIL."
+(defun only-static-in-attachments-p (object)
+  "Returns T, if the `object's flags are `cf-static-object' in
+  the attachments of `object's attached objects."
   (declare (type object object))
   (let* ((attached-object-names
            (mapcar #'car
@@ -384,22 +392,25 @@ always `cf-static-object', else NIL."
                      *current-bullet-world*
                      (name object)))))
          (attachments-of-attached-objects
-           (mapcar #'attached-objects
-                   (mapcar (alexandria:curry #'object
-                                             *current-bullet-world*)
-                           attached-object-names)))
+           (mapcar
+            (alexandria:compose
+             #'attached-objects
+             (alexandria:curry #'object *current-bullet-world*))
+           attached-object-names))
          (attachments-to-object
-           (mapcar #'car
-                   (loop for attachments in attachments-of-attached-objects
-                         collecting
-                         (remove-if-not (lambda (attach)
-                                          (equalp (car
-                                                   attach)
-                                                  (name object)))
-                                        attachments))))
+           (mapcar 
+            #'car
+            (loop for attachments in attachments-of-attached-objects
+                  collecting
+                  (remove-if-not (alexandria:curry 
+                                  #'equalp
+                                  (name object))
+                                 attachments :key #'car))))
          (collision-information-list
-           (remove-if-not #'identity
-                          (mapcar #'caddr attachments-to-object))))
+           (mapcar
+            #'caddr
+            (remove-if-not #'identity
+                           attachments-to-object))))
 
     (when collision-information-list
       (every (alexandria:curry #'equalp '(:cf-static-object))

--- a/cram_3d_world/cram_bullet_reasoning/tests/items-tests.lisp
+++ b/cram_3d_world/cram_bullet_reasoning/tests/items-tests.lisp
@@ -33,6 +33,7 @@
 (define-test attach-object-bidirectional-and-attachment-type
   ;; Attaches two objects and check their attached objects and the
   ;; attachment-type of these
+  (spawn-robot)
   (btr-utils:spawn-object 'o1 :mug :pose 
                           '((-1 0.0 0.92)(0 0 0 1)))
   (btr-utils:spawn-object 'o2 :mug :pose 
@@ -62,6 +63,7 @@
 
 (define-test attach-object-bidirectional-more-than-two-objects
   ;; Attaches three objects and 'o1 is connected with both objects
+  (spawn-robot)
   (btr-utils:spawn-object 'o1 :mug :pose 
                           '((-1 0.0 0.92)(0 0 0 1)))
   (btr-utils:spawn-object 'o2 :mug :pose 
@@ -98,6 +100,7 @@
 (define-test attach-object-more-objects-connected-bidirectional-to-one-object-in-one-call
   ;; Attaches three objects and 'o1 is connected with both objects in
   ;; one call
+  (spawn-robot)
   (btr-utils:spawn-object 'o1 :mug :pose 
                           '((-1 0.0 0.92)(0 0 0 1)))
   (btr-utils:spawn-object 'o2 :mug :pose 
@@ -134,6 +137,7 @@
 (define-test attach-object-more-objects-connected-unidirectional-to-one-object-in-one-call
   ;; Attaches three objects and 'o1 is connected loose with both
   ;; objects in one call
+  (spawn-robot)
   (btr-utils:spawn-object 'o1 :mug :pose 
                           '((-1 0.0 0.92)(0 0 0 1)))
   (btr-utils:spawn-object 'o2 :mug :pose 
@@ -182,6 +186,7 @@
 (define-test attach-object-unidirectional
   ;; Attaches two objects unidirectional and check if loose attachment
   ;; was properly saved in the attachment
+  (spawn-robot)
   (btr-utils:spawn-object 'o1 :mug :pose 
                           '((-1 0.0 0.92)(0 0 0 1)))
   (btr-utils:spawn-object 'o2 :mug :pose 
@@ -215,6 +220,7 @@
   ;; bidirectional with the mug and attach it loose to a hook. Therefore the loose attachment of
   ;; the mug and tray-1 should be removed and the hook and handle should be in an loose
   ;; connection.
+  (spawn-robot)
   (btr-utils:spawn-object 'handle :mug :pose         ;;
                           '((-1 0.0 0.92)(0 0 0 1))) ;;  
   (btr-utils:spawn-object 'mug :mug :pose            ;;                                                  (X)
@@ -272,6 +278,7 @@
 
 (define-test detach-object-simple-and-bidirectional-attachments
   ;; Detaches two bidirectional conntected objects
+  (spawn-robot)
   (btr-utils:spawn-object 'oo1 :mug :pose 
                           '((-1 0.0 0.92)(0 0 0 1)))
   (btr-utils:spawn-object 'oo2 :mug :pose 
@@ -299,6 +306,7 @@
 
 (define-test detach-object-dont-remove-other-attachments-and-unidirectional
   ;; Detaches two objects where one object has one attached object
+  (spawn-robot)
   (btr-utils:spawn-object 'oo1 :mug :pose 
                           '((-1 0.0 0.92)(0 0 0 1)))
   (btr-utils:spawn-object 'oo2 :mug :pose 
@@ -393,8 +401,485 @@
   (btr:remove-object btr:*current-bullet-world* 'oo4)
   (btr:remove-object btr:*current-bullet-world* 'oo5))
 
+(define-test attach-object-with-static-objects-correct-collision-information 
+  (spawn-robot)
+  (btr-utils:spawn-object 'oo1 :mug :pose 
+                          '((-1 0.0 0.92)(0 0 0 1)))
+  (btr-utils:spawn-object 'oo2 :mug :pose 
+                          '((-1 0.0 0.92)(0 0 0 1)))
+  (btr-utils:spawn-object 'oo3 :mug :pose 
+                          '((-1 0.0 0.92)(0 0 0 1)))
+  (loop for body in (apply 'concatenate 'list
+                           (list (btr:rigid-bodies (btr:object
+                                                    btr:*current-bullet-world*
+                                                    'oo1))
+                                 (btr:rigid-bodies (btr:object
+                                                    btr:*current-bullet-world*
+                                                    'oo2))
+                                 (btr:rigid-bodies (btr:object
+                                                    btr:*current-bullet-world*
+                                                    'oo3))))
+        do
+           (setf
+            (btr::collision-flags body)
+            :CF-STATIC-OBJECT))
+  (btr:attach-object 'oo1 'oo2)
+  (assert-equal
+   :CF-STATIC-OBJECT
+   (car (btr::collision-flags 
+         (car 
+          (btr:rigid-bodies 
+           (btr:object
+            btr:*current-bullet-world* 
+            'oo1))))))
+  (assert-equal
+   :CF-STATIC-OBJECT
+   (car (btr::collision-flags 
+         (car 
+          (btr:rigid-bodies 
+           (btr:object
+            btr:*current-bullet-world* 
+            'oo2))))))
+  (assert-equal
+   :CF-STATIC-OBJECT
+   (car
+    (btr::collision-information-flags
+     (caddr 
+      (find 'oo1
+            (btr:attached-objects
+             (btr:object
+              btr:*current-bullet-world*
+              'oo2))
+            :key #'car)))))
+  (assert-equal
+   :CF-STATIC-OBJECT
+   (car
+    (btr::collision-information-flags
+     (caddr 
+      (find 'oo2
+            (btr:attached-objects
+             (btr:object
+              btr:*current-bullet-world*
+              'oo1))
+            :key #'car)))))
+  (btr:attach-object 'oo1 'oo3)
+  (assert-equal
+   :CF-STATIC-OBJECT
+   (car (btr::collision-flags 
+         (car 
+          (btr:rigid-bodies 
+           (btr:object
+            btr:*current-bullet-world* 
+            'oo1))))))
+  (assert-equal
+   :CF-STATIC-OBJECT
+   (car (btr::collision-flags 
+         (car 
+          (btr:rigid-bodies 
+           (btr:object
+            btr:*current-bullet-world* 
+            'oo3))))))
+  (assert-equal
+   :CF-STATIC-OBJECT
+   (car
+    (btr::collision-information-flags
+     (caddr 
+      (find 'oo3
+            (btr:attached-objects
+             (btr:object
+              btr:*current-bullet-world*
+              'oo1))
+            :key #'car)))))
+  (assert-equal
+   :CF-STATIC-OBJECT
+   (car
+    (btr::collision-information-flags
+     (caddr 
+      (find 'oo1
+            (btr:attached-objects
+             (btr:object
+              btr:*current-bullet-world*
+              'oo3))
+            :key #'car)))))
+  (assert-equal
+   :CF-STATIC-OBJECT
+   (car
+    (btr::collision-information-flags
+     (caddr 
+      (find 'oo1
+            (btr:attached-objects
+             (btr:object
+              btr:*current-bullet-world*
+              'oo2))
+            :key #'car)))))
+  (assert-equal
+   :CF-STATIC-OBJECT
+   (car
+    (btr::collision-information-flags
+     (caddr 
+      (find 'oo2
+            (btr:attached-objects
+             (btr:object
+              btr:*current-bullet-world*
+              'oo1))
+            :key #'car)))))
+  (btr:remove-object btr:*current-bullet-world* 'oo1)
+  (btr:remove-object btr:*current-bullet-world* 'oo2)
+  (btr:remove-object btr:*current-bullet-world* 'oo3))
+
+(define-test attach-object-correct-collision-information 
+  (spawn-robot)
+  (btr-utils:spawn-object 'oo1 :mug :pose 
+                          '((-1 0.0 0.92)(0 0 0 1)))
+  (btr-utils:spawn-object 'oo2 :mug :pose 
+                          '((-1 0.0 0.92)(0 0 0 1)))
+  (btr-utils:spawn-object 'oo3 :mug :pose 
+                          '((-1 0.0 0.92)(0 0 0 1)))
+  (btr:attach-object 'oo1 'oo2)
+  (assert-equal
+   :CF-STATIC-OBJECT
+   (car (btr::collision-flags 
+         (car 
+          (btr:rigid-bodies 
+           (btr:object
+            btr:*current-bullet-world* 
+            'oo1))))))
+  (assert-equal
+   :CF-STATIC-OBJECT
+   (car (btr::collision-flags 
+         (car 
+          (btr:rigid-bodies 
+           (btr:object
+            btr:*current-bullet-world* 
+            'oo2))))))
+  (assert-equal
+   NIL
+   (car
+    (btr::collision-information-flags
+     (caddr 
+      (find 'oo1
+            (btr:attached-objects
+             (btr:object
+              btr:*current-bullet-world*
+              'oo2))
+            :key #'car)))))
+  (assert-equal
+   NIL
+   (car
+    (btr::collision-information-flags
+     (caddr 
+      (find 'oo2
+            (btr:attached-objects
+             (btr:object
+              btr:*current-bullet-world*
+              'oo1))
+            :key #'car)))))
+  (btr:attach-object 'oo1 'oo3)
+  (assert-equal
+   :CF-STATIC-OBJECT
+   (car (btr::collision-flags 
+         (car 
+          (btr:rigid-bodies 
+           (btr:object
+            btr:*current-bullet-world* 
+            'oo1))))))
+  (assert-equal
+   :CF-STATIC-OBJECT
+   (car (btr::collision-flags 
+         (car 
+          (btr:rigid-bodies 
+           (btr:object
+            btr:*current-bullet-world* 
+            'oo3))))))
+  (assert-equal
+   NIL
+   (car
+    (btr::collision-information-flags
+     (caddr 
+      (find 'oo3
+            (btr:attached-objects
+             (btr:object
+              btr:*current-bullet-world*
+              'oo1))
+            :key #'car)))))
+  (assert-equal
+   NIL
+   (car
+    (btr::collision-information-flags
+     (caddr 
+      (find 'oo1
+            (btr:attached-objects
+             (btr:object
+              btr:*current-bullet-world*
+              'oo3))
+            :key #'car)))))
+  (assert-equal
+   NIL
+   (car
+    (btr::collision-information-flags
+     (caddr 
+      (find 'oo1
+            (btr:attached-objects
+             (btr:object
+              btr:*current-bullet-world*
+              'oo2))
+            :key #'car)))))
+  (assert-equal
+   NIL
+   (car
+    (btr::collision-information-flags
+     (caddr 
+      (find 'oo2
+            (btr:attached-objects
+             (btr:object
+              btr:*current-bullet-world*
+              'oo1))
+            :key #'car)))))
+  (btr:remove-object btr:*current-bullet-world* 'oo1)
+  (btr:remove-object btr:*current-bullet-world* 'oo2)
+  (btr:remove-object btr:*current-bullet-world* 'oo3))
+
+(define-test detach-object-correct-collision-information
+  (spawn-robot)
+  (btr-utils:spawn-object 'oo1 :mug :pose 
+                          '((-1 0.0 0.92)(0 0 0 1)))
+  (btr-utils:spawn-object 'oo2 :mug :pose 
+                          '((-1 0.0 0.92)(0 0 0 1)))
+  (btr-utils:spawn-object 'oo3 :mug :pose 
+                          '((-1 0.0 0.92)(0 0 0 1)))
+  (btr:attach-object 'oo1 'oo2)
+  (btr:attach-object 'oo1 'oo3)
+  (btr:detach-object 'oo1 'oo2)
+  (assert-equal
+   :CF-STATIC-OBJECT
+   (car (btr::collision-flags 
+         (car 
+          (btr:rigid-bodies 
+           (btr:object
+            btr:*current-bullet-world* 
+            'oo1))))))
+  (assert-equal
+   NIL
+   (car (btr::collision-flags 
+         (car 
+          (btr:rigid-bodies 
+           (btr:object
+            btr:*current-bullet-world* 
+            'oo2))))))
+  (assert-equal
+   :CF-STATIC-OBJECT
+   (car (btr::collision-flags 
+         (car 
+          (btr:rigid-bodies 
+           (btr:object
+            btr:*current-bullet-world* 
+            'oo3))))))
+  (assert-equal
+   NIL
+   (car
+    (btr::collision-information-flags
+     (caddr 
+      (find 'oo3
+            (btr:attached-objects
+             (btr:object
+              btr:*current-bullet-world*
+              'oo1))
+            :key #'car)))))
+  (assert-equal
+   NIL
+   (car
+    (btr::collision-information-flags
+     (caddr 
+      (find 'oo1
+            (btr:attached-objects
+             (btr:object
+              btr:*current-bullet-world*
+              'oo3))
+            :key #'car)))))
+  (assert-false
+   (btr:attached-objects
+    (btr:object
+     btr:*current-bullet-world*
+     'oo2)))
+  (btr:remove-object btr:*current-bullet-world* 'oo1)
+  (btr:remove-object btr:*current-bullet-world* 'oo2)
+  (btr:remove-object btr:*current-bullet-world* 'oo3))
+
+(define-test detach-object-with-static-objects-correct-collision-information
+  (spawn-robot)
+  (btr-utils:spawn-object 'oo1 :mug :pose 
+                          '((-1 0.0 0.92)(0 0 0 1)))
+  (btr-utils:spawn-object 'oo2 :mug :pose 
+                          '((-1 0.0 0.92)(0 0 0 1)))
+  (btr-utils:spawn-object 'oo3 :mug :pose 
+                          '((-1 0.0 0.92)(0 0 0 1)))
+  (loop for body in (apply 'concatenate 'list
+                           (list (btr:rigid-bodies (btr:object
+                                                    btr:*current-bullet-world*
+                                                    'oo1))
+                                 (btr:rigid-bodies (btr:object
+                                                    btr:*current-bullet-world*
+                                                    'oo2))
+                                 (btr:rigid-bodies (btr:object
+                                                    btr:*current-bullet-world*
+                                                    'oo3))))
+        do
+           (setf
+            (btr::collision-flags body)
+            :CF-STATIC-OBJECT))
+  (btr:attach-object 'oo1 'oo2)
+  (btr:attach-object 'oo1 'oo3)
+  (btr:detach-object 'oo1 'oo2)
+  (assert-equal
+   :CF-STATIC-OBJECT
+     (car (btr::collision-flags 
+           (car 
+            (btr:rigid-bodies 
+             (btr:object
+              btr:*current-bullet-world* 
+              'oo1))))))
+    (assert-equal
+     :CF-STATIC-OBJECT
+     (car (btr::collision-flags 
+           (car 
+            (btr:rigid-bodies 
+             (btr:object
+              btr:*current-bullet-world* 
+              'oo2))))))
+    (assert-equal
+     :CF-STATIC-OBJECT
+     (car (btr::collision-flags 
+           (car 
+            (btr:rigid-bodies 
+             (btr:object
+              btr:*current-bullet-world* 
+              'oo3))))))
+    (assert-equal
+     :CF-STATIC-OBJECT
+     (car
+      (btr::collision-information-flags
+       (caddr 
+        (find 'oo3
+              (btr:attached-objects
+               (btr:object
+                btr:*current-bullet-world*
+                'oo1))
+              :key #'car)))))
+    (assert-equal
+     :CF-STATIC-OBJECT
+     (car
+      (btr::collision-information-flags
+       (caddr 
+        (find 'oo1
+              (btr:attached-objects
+               (btr:object
+                btr:*current-bullet-world*
+                'oo3))
+              :key #'car)))))
+    (assert-false
+     (btr:attached-objects
+      (btr:object
+       btr:*current-bullet-world*
+       'oo2)))
+    (btr:remove-object btr:*current-bullet-world* 'oo1)
+    (btr:remove-object btr:*current-bullet-world* 'oo2)
+    (btr:remove-object btr:*current-bullet-world* 'oo3))
+
+(define-test attach-object-and-detach-object-shopping-demo-collision-flagsy
+  (spawn-robot)
+  (spawn-kitchen)
+  (btr-utils:spawn-object 'basket :mug :pose 
+                          '((-1 0.0 0.92)(0 0 0 1)))
+  (btr-utils:spawn-object 'oo1 :mug :pose 
+                          '((-1 0.0 0.92)(0 0 0 1)))
+  ;; Attach object to environment and basket to the robot
+  (btr:attach-object (btr:get-robot-object)
+                     (btr:object btr:*current-bullet-world* 'basket)
+                     :link "r_wrist_roll_link" :loose nil :grasp :front)
+  (btr:attach-object (btr:get-environment-object)
+                     (btr:object btr:*current-bullet-world* 'oo1 )
+                     :link "sink_area_surface")
+  (assert-equal
+   :CF-STATIC-OBJECT
+   (car (btr::collision-flags 
+         (car 
+          (btr:rigid-bodies 
+           (btr:object
+            btr:*current-bullet-world* 
+            'basket))))))
+  (assert-equal
+   :CF-STATIC-OBJECT
+   (car (btr::collision-flags 
+         (car 
+          (btr:rigid-bodies 
+           (btr:object
+            btr:*current-bullet-world* 
+            'basket))))))
+  ;; Robot grasps the object
+  ;; 1. detached from the env
+  (btr:detach-object (btr:get-environment-object) 
+                     (btr:object btr:*current-bullet-world* 'oo1))
+  (assert-equal
+   NIL
+   (car (btr::collision-flags 
+         (car 
+          (btr:rigid-bodies 
+           (btr:object
+            btr:*current-bullet-world* 
+            'oo1))))))
+  ;; 2. attached to the robot
+  (btr:attach-object (btr:get-robot-object)
+                     (btr:object btr:*current-bullet-world* 'oo1)
+                     :link "l_wrist_roll_link" :loose nil :grasp :front)
+  (assert-equal
+   :CF-STATIC-OBJECT
+   (car (btr::collision-flags 
+         (car 
+          (btr:rigid-bodies 
+           (btr:object
+            btr:*current-bullet-world* 
+            'oo1))))))
+  ;; Place object into the basket
+  (btr:detach-object (btr:get-robot-object)
+                     (btr:object btr:*current-bullet-world* 'oo1)
+                     :link "l_wrist_roll_link")
+  ;; Object oo1 falls in the basket
+  (assert-equal
+   NIL
+   (car (btr::collision-flags 
+         (car 
+          (btr:rigid-bodies 
+           (btr:object
+            btr:*current-bullet-world* 
+            'oo1))))))
+  ;; Attach object to the basket
+  (btr:attach-object 'basket 'oo1)
+  (assert-equal
+   :CF-STATIC-OBJECT
+   (car (btr::collision-flags 
+         (car 
+          (btr:rigid-bodies 
+           (btr:object
+            btr:*current-bullet-world* 
+            'basket))))))
+  (assert-equal
+   :CF-STATIC-OBJECT
+   (car (btr::collision-flags 
+         (car 
+          (btr:rigid-bodies 
+           (btr:object
+            btr:*current-bullet-world* 
+            'oo1))))))
+  (btr:remove-object btr:*current-bullet-world* 'oo1)
+  (btr:remove-object btr:*current-bullet-world* 'basket)
+  (btr:detach-all-objects (btr:get-robot-object))
+  (btr:detach-all-objects (btr:get-environment-object)))
+
+
+
 (define-test get-loose-attached-objects-simple
   ;; Returns the loose attachments of an object
+  (spawn-robot)
   (btr-utils:spawn-object 'oo1 :mug :pose 
                           '((-1 0.0 0.92)(0 0 0 1)))
   (btr-utils:spawn-object 'oo2 :mug :pose 
@@ -438,6 +923,7 @@
 
 (define-test remove-loose-attachment-for-simple
   ;; Removes the loose attachments of an object
+  (spawn-robot)
   (btr-utils:spawn-object 'oo1 :mug :pose 
                           '((-1 0.0 0.92)(0 0 0 1)))
   (btr-utils:spawn-object 'oo2 :mug :pose 
@@ -487,6 +973,7 @@
   ;; Attaches a new pose to an item with attached items,
   ;; so the pose of the attached items should change relative to the
   ;; item they are attached to too.
+  (spawn-robot)
   (btr-utils:spawn-object 'oo1 :mug :pose 
                           '((-1 0.0 0.9)(0 0 0 1)))
   (btr-utils:spawn-object 'oo2 :mug :pose 

--- a/cram_3d_world/cram_bullet_reasoning/tests/items-tests.lisp
+++ b/cram_3d_world/cram_bullet_reasoning/tests/items-tests.lisp
@@ -785,7 +785,7 @@
     (btr:remove-object btr:*current-bullet-world* 'oo2)
     (btr:remove-object btr:*current-bullet-world* 'oo3))
 
-(define-test attach-object-and-detach-object-shopping-demo-collision-flagsy
+(define-test attach-object-and-detach-object-shopping-demo-collision-flags
   (spawn-robot)
   (spawn-kitchen)
   (btr-utils:spawn-object 'basket :mug :pose 
@@ -875,6 +875,106 @@
   (btr:detach-all-objects (btr:get-robot-object))
   (btr:detach-all-objects (btr:get-environment-object)))
 
+(define-test attach-object-and-detach-static-object-shopping-demo-collision-flags
+  (spawn-robot)
+  (spawn-kitchen)
+  (btr-utils:spawn-object 'basket :mug :pose 
+                          '((-1 0.0 0.92)(0 0 0 1)))
+  (btr-utils:spawn-object 'oo1 :mug :pose 
+                          '((-1 0.0 0.92)(0 0 0 1)))
+  (loop for body in (apply 'concatenate 'list
+                           (list (btr:rigid-bodies (btr:object
+                                                    btr:*current-bullet-world*
+                                                    'oo1))
+                                 (btr:rigid-bodies (btr:object
+                                                    btr:*current-bullet-world*
+                                                    'basket))))
+        do
+           (setf
+            (btr::collision-flags body)
+            :CF-STATIC-OBJECT))
+  ;; Attach object to environment and basket to the robot
+  (btr:attach-object (btr:get-robot-object)
+                     (btr:object btr:*current-bullet-world* 'basket)
+                     :link "r_wrist_roll_link" :loose nil :grasp :front)
+  (btr:attach-object (btr:get-environment-object)
+                     (btr:object btr:*current-bullet-world* 'oo1 )
+                     :link "sink_area_surface")
+  (assert-equal
+   :CF-STATIC-OBJECT
+   (car (btr::collision-flags 
+         (car 
+          (btr:rigid-bodies 
+           (btr:object
+            btr:*current-bullet-world* 
+            'basket))))))
+  (assert-equal
+   :CF-STATIC-OBJECT
+   (car (btr::collision-flags 
+         (car 
+          (btr:rigid-bodies 
+           (btr:object
+            btr:*current-bullet-world* 
+            'basket))))))
+  ;; Robot grasps the object
+  ;; 1. detached from the env
+  (btr:detach-object (btr:get-environment-object) 
+                     (btr:object btr:*current-bullet-world* 'oo1))
+  (assert-equal
+   :CF-STATIC-OBJECT
+   (car (btr::collision-flags 
+         (car 
+          (btr:rigid-bodies 
+           (btr:object
+            btr:*current-bullet-world* 
+            'oo1))))))
+  ;; 2. attached to the robot
+  (btr:attach-object (btr:get-robot-object)
+                     (btr:object btr:*current-bullet-world* 'oo1)
+                     :link "l_wrist_roll_link" :loose nil :grasp :front)
+  (assert-equal
+   :CF-STATIC-OBJECT
+   (car (btr::collision-flags 
+         (car 
+          (btr:rigid-bodies 
+           (btr:object
+            btr:*current-bullet-world* 
+            'oo1))))))
+  ;; Place object into the basket
+  (btr:detach-object (btr:get-robot-object)
+                     (btr:object btr:*current-bullet-world* 'oo1)
+                     :link "l_wrist_roll_link")
+  ;; Object oo1 falls in the basket
+  (assert-equal
+   :CF-STATIC-OBJECT
+   (car (btr::collision-flags 
+         (car 
+          (btr:rigid-bodies 
+           (btr:object
+            btr:*current-bullet-world* 
+            'oo1))))))
+  ;; Attach object to the basket
+  (btr:attach-object 'basket 'oo1)
+  (assert-equal
+   :CF-STATIC-OBJECT
+   (car (btr::collision-flags 
+         (car 
+          (btr:rigid-bodies 
+           (btr:object
+            btr:*current-bullet-world* 
+            'basket))))))
+  (assert-equal
+   :CF-STATIC-OBJECT
+   (car (btr::collision-flags 
+         (car 
+          (btr:rigid-bodies 
+           (btr:object
+            btr:*current-bullet-world* 
+            'oo1))))))
+  (btr:remove-object btr:*current-bullet-world* 'oo1)
+  (btr:remove-object btr:*current-bullet-world* 'basket)
+  (btr:detach-all-objects (btr:get-robot-object))
+  (btr:detach-all-objects (btr:get-environment-object)))
 
 
 (define-test get-loose-attached-objects-simple

--- a/cram_3d_world/cram_bullet_reasoning/tests/objects-tests.lisp
+++ b/cram_3d_world/cram_bullet_reasoning/tests/objects-tests.lisp
@@ -50,6 +50,30 @@
   (equal (pose->list pose)
          (pose->list other-pose)))
 
+(defun spawn-robot ()
+  (setf rob-int:*robot-urdf*
+        (cl-urdf:parse-urdf
+         (roslisp:get-param "robot_description")))
+  (prolog:prolog
+   `(and (btr:bullet-world ?world)
+         (rob-int:robot ?robot)
+         (assert (btr:object ?world :urdf ?robot ((0 0 0) (0 0 0 1))
+                             :urdf ,rob-int::*robot-urdf*))
+         (assert (btr:joint-state ?world ?robot (("torso_lift_joint"
+                                                  0.15d0))))))
+  (btr:detach-all-objects (btr:get-robot-object)))
+
+(defun spawn-kitchen ()
+  (let ((kitchen-urdf
+          (cl-urdf:parse-urdf
+           (roslisp:get-param "kitchen_description"))))
+    (prolog:prolog
+     `(and (btr:bullet-world ?world)
+           (man-int:environment-name ?environment-name)
+           (assert (btr:object ?world :urdf ?environment-name ((0 0 0) (0 0 0 1))
+                                            :urdf ,kitchen-urdf)))))
+  (btr:detach-all-objects (btr:get-environment-object)))
+
 
 (define-test create-static-collision-information-works
   ;; Tests if the collision information is properly saved and if it
@@ -73,17 +97,251 @@
   ;; recreate begin state for next test case
   (btr:remove-object btr:*current-bullet-world* 'o1))
 
-
-(define-test reset-collision-information-works
-  ;; Tests if the collision information is properly reseted and if it has
-  ;; an effect on the object by simulating the bullet world
+(define-test create-static-collision-information-works-with-more-objects
+  ;; Tests if the collision information is properly saved and if it
+  ;; has an effect on the object by simulating the bullet world
   (btr-utils:spawn-object 'o1 :mug :pose
                           '((-1 0.0 0.92)(0 0 0 1)))
   (btr-utils:spawn-object 'o2 :mug :pose
                           '((-1 0.0 0.92)(0 0 0 1)))
+  (let* ((pose-o1 (btr:pose (btr:object btr:*current-bullet-world* 'o1)))
+         (pose-o2 (btr:pose (btr:object btr:*current-bullet-world* 'o2))))
 
+    (lisp-unit:assert-equal
+     NIL
+     (car
+      (btr::collision-information-flags
+       (car
+        (btr::create-static-collision-information
+         (btr:object btr:*current-bullet-world* 'o1))))))
+    (lisp-unit:assert-equal :CF-STATIC-OBJECT (car
+                                               (cl-bullet:collision-flags
+                                                (first
+                                                 (btr:rigid-bodies (btr:object
+                                                                    btr:*current-bullet-world* 'o1))))))
+    (lisp-unit:assert-equal
+     NIL
+     (car
+      (btr::collision-information-flags
+       (car
+        (btr::create-static-collision-information
+         (btr:object btr:*current-bullet-world* 'o2))))))
+    (lisp-unit:assert-equal :CF-STATIC-OBJECT (car
+                                               (cl-bullet:collision-flags
+                                                (first
+                                                 (btr:rigid-bodies (btr:object
+                                                                    btr:*current-bullet-world* 'o2))))))
+    (btr:simulate btr:*current-bullet-world* 1)
+    (let ((new-pose-o1
+            (btr:pose (btr:object btr:*current-bullet-world* 'o1)))
+          (new-pose-o2
+            (btr:pose (btr:object btr:*current-bullet-world* 'o2))))
+      (lisp-unit:assert-true (pose-equal pose-o1 new-pose-o1))
+      (lisp-unit:assert-true (pose-equal pose-o2 new-pose-o2))))
+
+  ;; recreate begin state for next test case
+  (btr:remove-object btr:*current-bullet-world* 'o1)
+  (btr:remove-object btr:*current-bullet-world* 'o2))
+
+(define-test create-static-collision-information-works-with-attached-objects
+  ;; Tests if the collision information is properly saved and if it
+  ;; has an effect on the object by simulating the bullet world
+  (spawn-robot)
+  (btr-utils:spawn-object 'o1 :mug :pose
+                          '((-1 0.0 0.92)(0 0 0 1)))
+  (btr-utils:spawn-object 'o2 :mug :pose
+                          '((-1 0.0 0.92)(0 0 0 1)))
+  (btr-utils:spawn-object 'o3 :mug :pose
+                          '((-1 0.0 0.92)(0 0 0 1)))
+  (btr:attach-object 'o1 'o3)
+  (let* ((pose-o1 (btr:pose (btr:object btr:*current-bullet-world* 'o1)))
+         (pose-o2 (btr:pose (btr:object btr:*current-bullet-world* 'o2))))
+    
+    (lisp-unit:assert-equal
+     NIL
+     (car
+      (btr::collision-information-flags
+       (car
+        (btr::create-static-collision-information
+         (btr:object btr:*current-bullet-world* 'o1))))))
+    (lisp-unit:assert-equal :CF-STATIC-OBJECT (car
+                                               (cl-bullet:collision-flags
+                                                (first
+                                                 (btr:rigid-bodies 
+                                                  (btr:object
+                                                   btr:*current-bullet-world* 
+                                                   'o1))))))
+    (lisp-unit:assert-equal
+     NIL
+     (car
+      (btr::collision-information-flags
+       (car
+        (btr::create-static-collision-information
+         (btr:object btr:*current-bullet-world* 'o2))))))
+    (lisp-unit:assert-equal :CF-STATIC-OBJECT (car
+                                               (cl-bullet:collision-flags
+                                                (first
+                                                 (btr:rigid-bodies 
+                                                  (btr:object
+                                                   btr:*current-bullet-world*
+                                                   'o2))))))
+    (btr:simulate btr:*current-bullet-world* 1)
+    (let ((new-pose-o1
+            (btr:pose (btr:object btr:*current-bullet-world* 'o1)))
+          (new-pose-o2
+            (btr:pose (btr:object btr:*current-bullet-world* 'o2))))
+      (lisp-unit:assert-true (pose-equal pose-o1 new-pose-o1))
+      (lisp-unit:assert-true (pose-equal pose-o2 new-pose-o2))))
+  ;; recreate begin state for next test case
+  (btr:remove-object btr:*current-bullet-world* 'o1)
+  (btr:remove-object btr:*current-bullet-world* 'o2)
+  (btr:remove-object btr:*current-bullet-world* 'o3))
+
+(define-test create-static-collision-information-works-with-static-objects
+  ;; Tests if the collision information is properly saved and if it
+  ;; has an effect on the object by simulating the bullet world
+  (btr-utils:spawn-object 'o1 :mug :pose
+                          '((-1 0.0 0.92)(0 0 0 1)))
+  (btr-utils:spawn-object 'o2 :mug :pose
+                          '((-1 0.0 0.92)(0 0 0 1)))
+  (loop for body in (apply 'concatenate 'list
+                           (list (btr:rigid-bodies (btr:object
+                                                    btr:*current-bullet-world*
+                                                    'o1))
+                                 (btr:rigid-bodies (btr:object
+                                                    btr:*current-bullet-world*
+                                                    'o2))))
+        do
+           (setf
+            (btr::collision-flags body)
+            :CF-STATIC-OBJECT))
+  (let* ((pose-o1 (btr:pose (btr:object btr:*current-bullet-world* 'o1)))
+         (pose-o2 (btr:pose (btr:object btr:*current-bullet-world* 'o2))))
+    
+    (lisp-unit:assert-equal
+     :CF-STATIC-OBJECT
+     (car
+      (btr::collision-information-flags
+       (car
+        (btr::create-static-collision-information
+         (btr:object btr:*current-bullet-world* 'o1))))))
+    (lisp-unit:assert-equal :CF-STATIC-OBJECT (car
+                                               (cl-bullet:collision-flags
+                                                (first
+                                                 (btr:rigid-bodies 
+                                                  (btr:object
+                                                   btr:*current-bullet-world* 
+                                                   'o1))))))
+    (lisp-unit:assert-equal
+     :CF-STATIC-OBJECT
+     (car
+      (btr::collision-information-flags
+       (car
+        (btr::create-static-collision-information
+         (btr:object btr:*current-bullet-world* 'o2))))))
+    (lisp-unit:assert-equal :CF-STATIC-OBJECT (car
+                                               (cl-bullet:collision-flags
+                                                (first
+                                                 (btr:rigid-bodies 
+                                                  (btr:object
+                                                   btr:*current-bullet-world*
+                                                   'o2))))))
+    (btr:simulate btr:*current-bullet-world* 1)
+    (let ((new-pose-o1
+            (btr:pose (btr:object btr:*current-bullet-world* 'o1)))
+          (new-pose-o2
+            (btr:pose (btr:object btr:*current-bullet-world* 'o2))))
+      (lisp-unit:assert-true (pose-equal pose-o1 new-pose-o1))
+      (lisp-unit:assert-true (pose-equal pose-o2 new-pose-o2))))
+
+  ;; recreate begin state for next test case
+  (btr:remove-object btr:*current-bullet-world* 'o1)
+  (btr:remove-object btr:*current-bullet-world* 'o2))
+
+(define-test create-static-collision-information-works-with-attached-static-objects
+  ;; Tests if the collision information is properly saved and if it
+  ;; has an effect on the object by simulating the bullet world
+  (spawn-robot)
+  (btr-utils:spawn-object 'o1 :mug :pose
+                          '((-1 0.0 0.92)(0 0 0 1)))
+  (btr-utils:spawn-object 'o2 :mug :pose
+                          '((-1 0.0 0.92)(0 0 0 1)))
+  (btr-utils:spawn-object 'o3 :mug :pose
+                          '((-1 0.0 0.92)(0 0 0 1)))
+  (loop for body in (apply 'concatenate 'list
+                           (list (btr:rigid-bodies (btr:object
+                                                    btr:*current-bullet-world*
+                                                    'o1))
+                                 (btr:rigid-bodies (btr:object
+                                                    btr:*current-bullet-world*
+                                                    'o2))
+                                 (btr:rigid-bodies (btr:object
+                                                    btr:*current-bullet-world*
+                                                    'o3))))
+        do
+           (setf
+            (btr::collision-flags body)
+            :CF-STATIC-OBJECT))
+  (btr:attach-object (btr:object btr:*current-bullet-world* 'o1)
+                     (btr:object btr:*current-bullet-world* 'o3))
+  (let* ((pose-o1 (btr:pose (btr:object btr:*current-bullet-world* 'o1)))
+         (pose-o2 (btr:pose (btr:object btr:*current-bullet-world* 'o2))))
+    
+    (lisp-unit:assert-equal
+     :CF-STATIC-OBJECT
+     (car
+      (btr::collision-information-flags
+       (car
+        (btr::create-static-collision-information
+         (btr:object btr:*current-bullet-world* 'o1))))))
+    (lisp-unit:assert-equal :CF-STATIC-OBJECT (car
+                                               (cl-bullet:collision-flags
+                                                (first
+                                                 (btr:rigid-bodies 
+                                                  (btr:object
+                                                   btr:*current-bullet-world* 
+                                                   'o1))))))
+    (lisp-unit:assert-equal
+     :CF-STATIC-OBJECT
+     (car
+      (btr::collision-information-flags
+       (car
+        (btr::create-static-collision-information
+         (btr:object btr:*current-bullet-world* 'o2))))))
+    (lisp-unit:assert-equal :CF-STATIC-OBJECT (car
+                                               (cl-bullet:collision-flags
+                                                (first
+                                                 (btr:rigid-bodies 
+                                                  (btr:object
+                                                   btr:*current-bullet-world*
+                                                   'o2))))))
+    (btr:simulate btr:*current-bullet-world* 1)
+    (let ((new-pose-o1
+            (btr:pose (btr:object btr:*current-bullet-world* 'o1)))
+          (new-pose-o2
+            (btr:pose (btr:object btr:*current-bullet-world* 'o2))))
+      (lisp-unit:assert-true (pose-equal pose-o1 new-pose-o1))
+      (lisp-unit:assert-true (pose-equal pose-o2 new-pose-o2))))
+  ;; recreate begin state for next test case
+  (btr:remove-object btr:*current-bullet-world* 'o1)
+  (btr:remove-object btr:*current-bullet-world* 'o2)
+  (btr:remove-object btr:*current-bullet-world* 'o3))
+
+
+(define-test reset-collision-information-works-with-attached-objects
+  ;; Tests if the collision information is properly reseted and if it has
+  ;; an effect on the object by simulating the bullet world
+  (spawn-robot)
+  (btr-utils:spawn-object 'o1 :mug :pose
+                          '((-1 0.0 0.92)(0 0 0 1)))
+  (btr-utils:spawn-object 'o2 :mug :pose
+                          '((-1 0.0 0.92)(0 0 0 1)))
+  
   (let* ((pose-o1 (btr:pose (btr:object btr:*current-bullet-world* 'o1))))
     (btr:attach-object 'o1 'o2)
+    ;;simulate detachment
+    (setf (slot-value (btr:object btr:*current-bullet-world* 'o1) 'attached-objects)
+          nil)
     (btr::reset-collision-information (btr:object btr:*current-bullet-world* 'o1)
                                       (list (btr::make-collision-information
                                              :rigid-body-name 'o1 :flags NIL)))
@@ -95,9 +353,9 @@
     (btr:simulate btr:*current-bullet-world* 1)
     (let ((new-pose-o1
             (btr:pose (btr:object btr:*current-bullet-world* 'o1))))
-
+      
       (lisp-unit:assert-false (pose-equal pose-o1 new-pose-o1))))
-
+  
   ;; recreate begin state for next test case
   (btr:remove-object btr:*current-bullet-world* 'o1)
   (btr:remove-object btr:*current-bullet-world* 'o2))
@@ -113,11 +371,12 @@
 (define-test attach-object-called-with-item-symbols
   ;; Tests if the attach-object function gets properly called if it was
   ;; called with the object item names
+  (spawn-robot)
   (btr-utils:spawn-object 'oo1 :mug :pose
                           '((-1 0.0 0.92)(0 0 0 1)))
   (btr-utils:spawn-object 'oo2 :mug :pose
                           '((-1 0.0 0.92)(0 0 0 1)))
-
+  
   (btr:attach-object 'oo1 'oo2)
   (lisp-unit:assert-equal
    'oo1
@@ -128,7 +387,7 @@
    'oo2
    (car (assoc 'oo2 (btr:attached-objects
                      (btr:object btr:*current-bullet-world* 'oo1)))))
-
+  
   (btr:remove-object btr:*current-bullet-world* 'oo1)
   (btr:remove-object btr:*current-bullet-world* 'oo2))
 


### PR DESCRIPTION
There were false collision information saved as mentioned in [this](https://trello.com/c/EFbUJpwL/278-fix-pr-150-collision-flags-code) Trello card. This should be now fixed. Further tests covering this case were added:

- attach object a and b: when attaching object a and c, collision information is correct
- attach object a and b and attaching object a and c: when detaching object a and b, collision information is correct
- shopping demo scenario: attach basket to robot, attach object a to environment: simulate picking of a and placing of a in the basket by calling the attach- and detach-object methods in the sequence as specified by the events [object-attached-robot](https://github.com/cram2/cram/blob/boxy/cram_3d_world/cram_bullet_reasoning_belief_state/src/event-handlers.lisp#L87) and [object-detached-robot](https://github.com/cram2/cram/blob/boxy/cram_3d_world/cram_bullet_reasoning_belief_state/src/event-handlers.lisp#L381) in cram_btr_bf.

These test cases are written for static objects and for non-static objects.