### PR TITLE
[env-man] Fix distance clipping for opposite direction of actions

### DIFF
--- a/cram_3d_world/cram_fetch_deliver_plans/src/fetch-and-deliver-plans.lisp
+++ b/cram_3d_world/cram_fetch_deliver_plans/src/fetch-and-deliver-plans.lisp
@@ -150,7 +150,9 @@ if yes, relocate and retry, if no collisions, open or close container."
                 (ecase action-type
                   (:accessing
                    (let ((?goal
-                           `(cpoe:container-state ,?object-to-manipulate :open)))
+                           (if ?distance
+                               `(cpoe:container-state ,?object-to-manipulate ,?distance)
+                               `(cpoe:container-state ,?object-to-manipulate :open))))
                      (desig:an action
                                (type opening)
                                (arm ?arm)
@@ -160,7 +162,9 @@ if yes, relocate and retry, if no collisions, open or close container."
                                (goal ?goal))))
                   (:sealing
                    (let ((?goal
-                           `(cpoe:container-state ,?object-to-manipulate :closed)))
+                           (if ?distance
+                               `(cpoe:container-state ,?object-to-manipulate ,?distance)
+                               `(cpoe:container-state ,?object-to-manipulate :closed))))
                      (desig:an action
                                (type closing)
                                (arm ?arm)

--- a/cram_3d_world/cram_urdf_environment_manipulation/src/environment-occasions.lisp
+++ b/cram_3d_world/cram_urdf_environment_manipulation/src/environment-occasions.lisp
@@ -46,7 +46,7 @@
     (lisp-fun cl-urdf:name ?joint ?joint-name)
     (btr:joint-state ?world ?btr-environment ?joint-name ?joint-state)
     (or (and (lisp-type ?distance number)
-             (cram-tf:values-converged ?joint-state ?distance ?delta))
+             (lisp-pred cram-tf:values-converged ?joint-state ?distance ?delta))
         (and (member ?distance (:open :closed))
              (lisp-fun cl-urdf:limits ?joint ?joint-limits)
              (lisp-fun cl-urdf:lower ?joint-limits ?lower-limit)

--- a/cram_3d_world/cram_urdf_environment_manipulation/src/environment.lisp
+++ b/cram_3d_world/cram_urdf_environment_manipulation/src/environment.lisp
@@ -273,9 +273,12 @@ Using a default (1 0 0)."
         (:opening
          (if (> (+ state distance) upper-limit)
              (- upper-limit state)
-             distance))
+             (if (< (+ state distance) lower-limit)
+                 (- (- state lower-limit))
+                 distance)))
         (:closing
          (if (< (- state distance) lower-limit)
              (- state lower-limit)
-             distance))))))
-
+             (if (> (- state distance) upper-limit)
+                 (- (- upper-limit state))
+                 distance)))))))


### PR DESCRIPTION
Fixed the distance clipping in situations, where the relative distance is in the opposite direction of the usual direction of the action (eg. opening a drawer with a sealing action). In these cases the relative distance is negative, which was not covered by the clip-distance function.