### PR TITLE
Pick and Place Trajectories: Lifting Offset defined in given URDF-Frame or the Robots Base Frame  

### DIFF
--- a/cram_common/cram_manipulation_interfaces/cram-manipulation-interfaces-tests.asd
+++ b/cram_common/cram_manipulation_interfaces/cram-manipulation-interfaces-tests.asd
@@ -32,12 +32,16 @@
   :license "BSD"
 
   :depends-on (cram-manipulation-interfaces
+               cram-urdf-projection ;;because of urdf-proj:with-simulated-robot
+               cram-pr2-pick-place-demo
+               ;;cram-donbot-retail-demo
                lisp-unit
                cram-prolog
                )
   :components ((:module "tests"
                 :components
                 ((:file "package")
-                 (:file "object-hierarchy-tests" :depends-on ("package")))))
+                 (:file "object-hierarchy-tests" :depends-on ("package"))
+                 (:file "trajectories-tests" :depends-on ("package")))))
   :perform (test-op (operation component)
                     (symbol-call :lisp-unit '#:run-tests :all :cram-manipulation-interfaces-tests)))

--- a/cram_common/cram_manipulation_interfaces/src/package.lisp
+++ b/cram_common/cram_manipulation_interfaces/src/package.lisp
@@ -81,7 +81,7 @@
    ;;
    #:get-object-type-to-gripper-transform
    #:get-object-type-to-gripper-pregrasp-transforms
-   #:get-object-type-wrt-base-frame-lift-transforms
+   #:get-object-type-wrt-reference-frame-lift-transforms
    #:def-object-type-to-gripper-transforms
    #:get-object-grasping-poses
    ;;

--- a/cram_common/cram_manipulation_interfaces/tests/trajectories-tests.lisp
+++ b/cram_common/cram_manipulation_interfaces/tests/trajectories-tests.lisp
@@ -1,0 +1,108 @@
+;;;
+;;; Copyright (c) 2020, Thomas Lipps <tlipps@uni-bremen.de>
+;;; All rights reserved.
+;;;
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions are met:
+;;;
+;;;     * Redistributions of source code must retain the above copyright
+;;;       notice, this list of conditions and the following disclaimer.
+;;;     * Redistributions in binary form must reproduce the above copyright
+;;;       notice, this list of conditions and the following disclaimer in the
+;;;       documentation and/or other materials provided with the distribution.
+;;;     * Neither the name of the Institute for Artificial Intelligence/
+;;;       Universitaet Bremen nor the names of its contributors may be used to
+;;;       endorse or promote products derived from this software without
+;;;       specific prior written permission.
+;;;
+;;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+;;; LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+;;; CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+;;; SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+;;; CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+;;; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+;;; POSSIBILITY OF SUCH DAMAGE.
+
+(in-package :man-int-tests)
+
+;; Run Tests in kitchen environment with PR2 or
+;; in the retail environment with donbot
+(defvar *run-pr2-pp-demo* T)
+(defvar *run-donbot-retail-demo* NIL)
+
+(defun vec-list-eqp (vec1 vec2 &optional (valid-diff 0.02))
+  (let ((ret T))
+    (loop for v in vec1
+          for w in vec2 do
+            (when (> (abs (- (abs v) (abs w)))
+                     valid-diff)
+              (setf ret nil)))
+  ret))
+
+(defun round-to (number &optional (precision 5) (what #'round))
+        (let ((div (expt 5 precision)))
+          (/ (funcall what (* number div)) div)))
+
+(when *run-pr2-pp-demo*
+  (defun init-tests-pr2-pp-setting-demo ()
+    (roslisp-utilities:startup-ros)
+    (demo::init-projection)
+    (urdf-proj:with-simulated-robot
+      (demo::spawn-objects-on-fixed-spots))))
+
+(when *run-donbot-retail-demo*
+  (defun init-tests-donbot-retail-demo ()
+    (roslisp-utilities:startup-ros)
+    (demo::init-projection)
+    (urdf-proj:with-simulated-robot
+      (demo::spawn-objects-on-small-shelf))))
+
+(when *run-pr2-pp-demo*
+  (define-test get-lift-transforms-in-base-household-milk-in-fridge-main
+    (init-tests-pr2-pp-setting-demo)
+    (sleep 2)
+    (let ((calculated-lift-tfs
+            (urdf-proj:with-simulated-robot
+              (man-int::get-lift-transforms-in-base 
+               :milk :milk-1 :right :back :fridge :iai-fridge-main)))
+          (defined-lift-tfs
+            (man-int:get-object-type-wrt-reference-frame-lift-transforms
+             :milk :right :back :fridge)))
+      (loop for calc-tf in calculated-lift-tfs
+            for def-tf in defined-lift-tfs do
+              (let ((calc-vec (cl-tf:translation calc-tf))
+                    (def-vec (cl-tf:translation def-tf)))
+                (destructuring-bind (c-x c-y c-z) 
+                    (mapcar #'round-to (cram-tf:3d-vector->list calc-vec))
+                  (destructuring-bind (d-x d-y d-z)
+                      (mapcar #'round-to (cram-tf:3d-vector->list def-vec))
+                    (assert-true (and (equalp c-x (* -1 d-x))
+                                      (equalp c-y d-y)
+                                      (equalp c-z d-z))))))))))
+
+(when *run-donbot-retail-demo*
+  (define-test get-lift-transforms-in-base-retail-dishwasher-tabs-in-shelf
+    (init-tests-donbot-retail-demo)
+    (sleep 2)
+    (loop for grasp in '(:top :back :front) do
+      (let ((calculated-lift-tfs
+              (urdf-proj:with-simulated-robot
+                (man-int::get-lift-transforms-in-base 
+                 :dish-washer-tabs :dish-washer-tabs-1 :right grasp :shelf :shelf-2-base)))
+            (defined-lift-tfs
+              (man-int:get-object-type-wrt-reference-frame-lift-transforms
+               :dish-washer-tabs :right grasp :shelf)))
+        (loop for calc-tf in calculated-lift-tfs
+              for def-tf in defined-lift-tfs do
+                (let ((calc-vec (cl-tf:translation calc-tf))
+                      (def-vec (cl-tf:translation def-tf)))
+                  (destructuring-bind (c-x c-y c-z) 
+                      (mapcar #'round-to (cram-tf:3d-vector->list calc-vec))
+                    (destructuring-bind (d-x d-y d-z)
+                        (mapcar #'round-to (cram-tf:3d-vector->list def-vec))
+                      (assert-true (vec-list-eqp (list c-x c-y c-z)
+                                                 (list d-x (* -1 d-y) d-z)))))))))))

--- a/cram_common/cram_mobile_pick_place_plans/src/pick-place-designators.lisp
+++ b/cram_common/cram_mobile_pick_place_plans/src/pick-place-designators.lisp
@@ -88,14 +88,17 @@
                    (desig:current-designator ?obj-loc ?curr-obj-loc)
                    (man-int:location-reference-object ?curr-obj-loc ?obj-loc-obj)
                    (desig:current-designator ?obj-loc-obj ?curr-obj-loc-obj)
-                   (spec:property ?curr-obj-loc-obj (:type ?location-type)))
-              (equal ?location-type NIL)))
+                   (spec:property ?curr-obj-loc-obj (:type ?location-type))
+                   (spec:property ?curr-obj-loc-obj (:urdf-name ?urdf-name)))
+              (and (equal ?location-type NIL)
+                   (equal ?urdf-name NIL))))
 
     ;; calculate trajectory
     (equal ?objects (?current-object-desig))
+
     (-> (equal ?arm :left)
         (and (lisp-fun man-int:get-action-trajectory :picking-up
-                       ?arm ?grasp ?location-type ?objects
+                       ?arm ?grasp ?location-type ?objects :urdf-name ?urdf-name
                        ?left-trajectory)
              (lisp-fun man-int:get-traj-poses-by-label ?left-trajectory :reaching
                        ?left-reach-poses)
@@ -108,7 +111,7 @@
              (equal ?left-lift-poses NIL)))
     (-> (equal ?arm :right)
         (and (lisp-fun man-int:get-action-trajectory :picking-up
-                       ?arm ?grasp ?location-type ?objects
+                       ?arm ?grasp ?location-type ?objects :urdf-name ?urdf-name
                        ?right-trajectory)
              (lisp-fun man-int:get-traj-poses-by-label ?right-trajectory :reaching
                        ?right-reach-poses)
@@ -201,8 +204,10 @@
               (equal ?placement-location-name NIL)))
     ;; get the type of the placement location, because the trajectory
     ;; might be different depending on the location type
-    (once (or (spec:property ?other-object-designator (:type ?location-type))
-              (equal ?location-type NIL)))
+    (once (or (and (spec:property ?other-object-designator (:type ?location-type))
+                   (spec:property ?other-object-designator (:urdf-name ?urdf-name)))
+              (and (equal ?location-type NIL)
+                   (equal ?urdf-name NIL))))
     ;; infer the grasp type
     (once (or (spec:property ?action-designator (:grasp ?grasp))
               (cpoe:object-in-hand ?object-designator ?arm ?grasp)))
@@ -215,6 +220,7 @@
         (and (lisp-fun man-int:get-action-trajectory :placing
                        ?arm ?grasp ?location-type ?objects
                        :target-object-transform-in-base ?target-object-transform
+                       :urdf-name ?urdf-name
                        ?left-trajectory)
              (lisp-fun man-int:get-traj-poses-by-label ?left-trajectory :reaching
                        ?left-reach-poses)
@@ -229,6 +235,7 @@
         (and (lisp-fun man-int:get-action-trajectory :placing
                        ?arm ?grasp ?location-type ?objects
                        :target-object-transform-in-base ?target-object-transform
+                       :urdf-name ?urdf-name
                        ?right-trajectory)
              (lisp-fun man-int:get-traj-poses-by-label ?right-trajectory :reaching
                        ?right-reach-poses)

--- a/cram_common/cram_object_knowledge/src/household.lisp
+++ b/cram_common/cram_object_knowledge/src/household.lisp
@@ -285,6 +285,15 @@
   :lift-translation *lift-offset*
   :2nd-lift-translation *lift-offset*)
 
+(man-int:def-object-type-to-gripper-transforms :milk '(:left :right) :back
+  :location-type :fridge
+  :grasp-translation `(,*milk-grasp-xy-offset* 0.0d0 ,*milk-grasp-z-offset*)
+  :grasp-rot-matrix man-int:*-x-across-z-grasp-rotation*
+  :pregrasp-offsets `(,(- *milk-pregrasp-xy-offset*) 0.0 ,*lift-z-offset*)
+  :2nd-pregrasp-offsets `(,(- *milk-pregrasp-xy-offset*) 0.0 0.0)
+  :lift-translation *lift-offset*
+  :2nd-lift-translation `(0.3 0 0.05))
+
 ;; FRONT grasp
 (man-int:def-object-type-to-gripper-transforms :milk '(:left :right) :front
   :grasp-translation `(,(- *milk-grasp-xy-offset*) 0.0d0 ,*milk-grasp-z-offset*)
@@ -293,6 +302,15 @@
   :2nd-pregrasp-offsets `(,*milk-pregrasp-xy-offset* 0.0 0.0)
   :lift-translation *lift-offset*
   :2nd-lift-translation *lift-offset*)
+
+(man-int:def-object-type-to-gripper-transforms :milk '(:left :right) :front
+  :location-type :fridge
+  :grasp-translation `(,(- *milk-grasp-xy-offset*) 0.0d0 ,*milk-grasp-z-offset*)
+  :grasp-rot-matrix man-int:*x-across-z-grasp-rotation*
+  :pregrasp-offsets `(,*milk-pregrasp-xy-offset* 0.0 ,*lift-z-offset*)
+  :2nd-pregrasp-offsets `(,*milk-pregrasp-xy-offset* 0.0 0.0)
+  :lift-translation *lift-offset*
+  :2nd-lift-translation `(0.3 0 0.05))
 
 ;; SIDE grasp
 (man-int:def-object-type-to-gripper-transforms :milk '(:left :right) :left-side
@@ -679,7 +697,7 @@
               ((object-type (eql type))
                environment human
                (context (eql :table-setting)))
-            (make-location-in-fridge-door environment)))
+            (make-location-in-fridge environment)))
         '(:milk))
 
 (mapcar (lambda (type)

--- a/cram_common/cram_object_knowledge/src/multiple-trajectory-poses.lisp
+++ b/cram_common/cram_object_knowledge/src/multiple-trajectory-poses.lisp
@@ -84,26 +84,17 @@
     (cl-transforms:make-3d-vector 0.0 0.0 0.1)
     (cl-transforms:make-quaternion 1 0 0 0))))
 
-(defmethod man-int:get-object-type-wrt-base-frame-lift-transforms ((type (eql :shoe))
-                                                                   arm
-                                                                   (grasp (eql :top))
-                                                                   location)
+(defmethod man-int:get-object-type-wrt-reference-frame-lift-transforms ((type (eql :shoe))
+                                                                        arm
+                                                                        (grasp (eql :top))
+                                                                        location)
   (list
-   (cl-transforms-stamped:make-transform-stamped
-    cram-tf:*robot-base-frame*
-    cram-tf:*robot-base-frame*
-    0.0
+   (cl-tf:make-transform
     (cl-transforms:make-3d-vector 0.0 0.0 0.1)
     (cl-transforms:make-identity-rotation))
-   (cl-transforms-stamped:make-transform-stamped
-    cram-tf:*robot-base-frame*
-    cram-tf:*robot-base-frame*
-    0.0
+   (cl-tf:make-transform
     (cl-transforms:make-3d-vector 0.0 0.0 0.2)
     (cl-transforms:make-identity-rotation))
-   (cl-transforms-stamped:make-transform-stamped
-    cram-tf:*robot-base-frame*
-    cram-tf:*robot-base-frame*
-    0.0
+   (cl-tf:make-transform
     (cl-transforms:make-3d-vector 0.0 0.0 0.3)
     (cl-transforms:make-identity-rotation))))

--- a/cram_common/cram_object_knowledge/src/retail.lisp
+++ b/cram_common/cram_object_knowledge/src/retail.lisp
@@ -79,6 +79,7 @@
 
 ;; TOP grasp
 (man-int:def-object-type-to-gripper-transforms :dish-washer-tabs '(:left :right) :top
+  :location-type :robot
   :grasp-translation `(0.0
                        0.0
                        ,*dish-washer-tabs-grasp-z-offset*)
@@ -99,6 +100,7 @@
                           0.0
                           ,(+ *dish-washer-tabs-grasp-z-offset*
                               *dish-washer-tabs-lift-z-top-grasp-offset*)))
+
 
 ;; BACK grasp robot
 (man-int:def-object-type-to-gripper-transforms :dish-washer-tabs '(:left :right) :back
@@ -162,12 +164,9 @@
         (make-array '(3 3) :initial-contents rot-matrix))
        (cl-transforms:make-identity-rotation))))
 (defun make-base-transform (x y z)
-  (cl-transforms-stamped:make-transform-stamped
-    cram-tf:*robot-base-frame*
-    cram-tf:*robot-base-frame*
-    0.0
-    (cl-transforms:make-3d-vector x y z)
-    (cl-transforms:make-identity-rotation)))
+  (cl-transforms-stamped:make-transform
+   (cl-transforms:make-3d-vector x y z)
+   (cl-transforms:make-identity-rotation)))
 ;; grasp
 (defmethod man-int:get-object-type-to-gripper-transform
     ((object-type (eql :dish-washer-tabs))
@@ -211,7 +210,7 @@
        *dish-washer-tabs-small-lift-z-offset*)
     man-int:*-x-across-z-grasp-rotation-2*)))
 ;; postgrasp
-(defmethod man-int:get-object-type-wrt-base-frame-lift-transforms
+(defmethod man-int:get-object-type-wrt-reference-frame-lift-transforms
     ((type (eql :dish-washer-tabs))
      arm
      (grasp (eql :back))
@@ -228,8 +227,8 @@
     (+ *dish-washer-tabs-grasp-z-offset*
        *dish-washer-tabs-lift-z-other-grasp-offset*))
    (make-base-transform
-    (- *dish-washer-tabs-pregrasp-x-offset*)
     0.0
+    (- *dish-washer-tabs-pregrasp-x-offset*)
     (+ *dish-washer-tabs-grasp-z-offset*
        *dish-washer-tabs-lift-z-other-grasp-offset*))))
 
@@ -278,7 +277,7 @@
        *dish-washer-tabs-small-lift-z-offset*)
     man-int:*x-across-z-grasp-rotation-2*)))
 ;; postgrasp
-(defmethod man-int:get-object-type-wrt-base-frame-lift-transforms
+(defmethod man-int:get-object-type-wrt-reference-frame-lift-transforms
     ((type (eql :dish-washer-tabs))
      arm
      (grasp (eql :front))
@@ -295,11 +294,75 @@
     (+ *dish-washer-tabs-grasp-z-offset*
        *dish-washer-tabs-lift-z-other-grasp-offset*))
    (make-base-transform
-    *dish-washer-tabs-pregrasp-x-offset*
     0.0
+    (- *dish-washer-tabs-pregrasp-x-offset*)
     (+ *dish-washer-tabs-grasp-z-offset*
        *dish-washer-tabs-lift-z-other-grasp-offset*))))
-
+;; TOP grasp shelf
+;; grasp
+(defmethod man-int:get-object-type-to-gripper-transform
+    ((object-type (eql :dish-washer-tabs))
+     object-name
+     arm
+     (grasp (eql :top)))
+  (make-arm-transform
+   object-name arm
+   *dish-washer-tabs-grasp-x-offset*
+   0.0
+   *dish-washer-tabs-grasp-z-offset*
+   man-int:*z-across-x-grasp-rotation*))
+;; pregrasp
+(defmethod man-int:get-object-type-to-gripper-pregrasp-transforms
+    ((type (eql :dish-washer-tabs))
+     object-name
+     arm
+     (grasp (eql :top))
+     location
+     grasp-transform)
+  (list
+   (make-arm-transform
+    object-name arm
+    (- (+ *dish-washer-tabs-grasp-z-offset*
+       *dish-washer-tabs-lift-z-other-grasp-offset*))
+    0.0
+    *dish-washer-tabs-pregrasp-x-offset*
+    man-int:*z-across-x-grasp-rotation*)
+   (make-arm-transform
+    object-name arm
+    (- (+ *dish-washer-tabs-grasp-z-offset*
+        *dish-washer-tabs-lift-z-other-grasp-offset*))
+    0.0
+    *dish-washer-tabs-pregrasp-x-offset*
+    man-int:*z-across-x-grasp-rotation*)
+   (make-arm-transform
+    object-name arm
+    (- (+ *dish-washer-tabs-grasp-z-offset*
+       *dish-washer-tabs-small-lift-z-offset*))
+    0.0
+    *dish-washer-tabs-pregrasp-x-offset*
+    man-int:*z-across-x-grasp-rotation*)))
+;; postgrasp
+(defmethod man-int:get-object-type-wrt-reference-frame-lift-transforms
+    ((type (eql :dish-washer-tabs))
+     arm
+     (grasp (eql :top))
+     location)
+  (list
+   (make-base-transform
+    0.0
+    0.0
+    (+ *dish-washer-tabs-grasp-z-offset*
+       *dish-washer-tabs-small-lift-z-offset*))
+   (make-base-transform
+    0.0
+    0.0
+    (+ *dish-washer-tabs-grasp-z-offset*
+       *dish-washer-tabs-lift-z-other-grasp-offset*))
+   (make-base-transform
+    0.0
+    (- *dish-washer-tabs-pregrasp-x-offset*)
+    (+ *dish-washer-tabs-grasp-z-offset*
+       *dish-washer-tabs-lift-z-other-grasp-offset*))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; BALEA-BOTTLE ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -413,6 +476,13 @@
   :attachment-rot-matrix '(( 0  0  1)
                            ( 0  1  0)
                            (-1  0  0)))
+
+(man-int:def-object-type-in-other-object-transform :dish-washer-tabs :robot
+  :donbot-tray-top
+  :attachment-translation `(0.2 0.05 0.11)
+  :attachment-rot-matrix '((0  1  0)
+                           (1  0  0)
+                           (0  0 -1)))
 
 (man-int:def-object-type-in-other-object-transform :dish-washer-tabs :environment
   :donbot-shelf-1-front

--- a/cram_demos/cram_projection_demos/src/retail/demo.lisp
+++ b/cram_demos/cram_projection_demos/src/retail/demo.lisp
@@ -101,7 +101,7 @@
                                   ;; (owl-name "donbot_tray")
                                   (urdf-name plate)))
                     (for ?object)
-                    (attachments (donbot-tray-front donbot-tray-back)))))
+                    (attachments (donbot-tray-front donbot-tray-back donbot-tray-front)))))
 
     (exe:perform
      (desig:an action
@@ -287,7 +287,8 @@
                                   ?pose-in-base ?robot-link-name))
              (?attachment (ecase ?grasp
                             (:front :donbot-tray-front)
-                            (:back :donbot-tray-back))))
+                            (:back :donbot-tray-back)
+                            (:top :donbot-tray-top))))
         (exe:perform
          (an action
              (type placing)

--- a/cram_donbot/cram_donbot_retail_demo/src/demo.lisp
+++ b/cram_donbot/cram_donbot_retail_demo/src/demo.lisp
@@ -55,7 +55,9 @@
                             :color '(1 1 1))
     (btr:add-object btr:*current-bullet-world* :box-item
                     :denkmitgeschirrreinigernature-1
-                    '((1.75 -1.45 1.06) (0 0 0.7 0.7))
+                    ;;'((1.75 -1.45 1.06) (0 0 -0.7 0.7)) ;; BACK
+                    ;;'((1.75 -1.45 1.06) (-0.5 0.5 0.5 0.5)) ;; TOP
+                    '((1.75 -1.45 1.06) (0 0 0.7 0.7)) ;; FRONT
                     :mass 0.2
                     :color '(0 1 0 1.0)
                     :size '(0.057 0.018 0.074)
@@ -65,7 +67,7 @@
 
 (defun demo ()
   (spawn-objects-on-small-shelf)
-
+  (btr:simulate btr:*current-bullet-world* 10)
   (let* ((?environment-name
            (rob-int:get-environment-name))
          (?search-location
@@ -101,7 +103,7 @@
                                   ;; (owl-name "donbot_tray")
                                   (urdf-name plate)))
                     (for ?object)
-                    (attachments (donbot-tray-front donbot-tray-back)))))
+                    (attachments (donbot-tray-front donbot-tray-back donbot-tray-top)))))
 
     (exe:perform
      (desig:an action
@@ -287,7 +289,8 @@
                                   ?pose-in-base ?robot-link-name))
              (?attachment (ecase ?grasp
                             (:front :donbot-tray-front)
-                            (:back :donbot-tray-back))))
+                            (:back :donbot-tray-back)
+                            (:top :donbot-tray-top))))
         (exe:perform
          (an action
              (type placing)

--- a/cram_knowrob/cram_cloud_logger/src/object-interface.lisp
+++ b/cram_knowrob/cram_cloud_logger/src/object-interface.lisp
@@ -51,10 +51,10 @@
     ;;(format t "GRIPPER OPENING Result is ~a~% for the object: ~a~%" query-result object-type)
     query-result))
 
-(defmethod man-int:get-object-type-wrt-base-frame-lift-transforms :around (object-type
-                                                                           arm
-                                                                           grasp
-                                                                           location)
+(defmethod man-int:get-object-type-wrt-reference-frame-lift-transforms :around (object-type
+                                                                                arm
+                                                                                grasp
+                                                                                location)
   ;;(format t "Asking for GRIPPER LIFT TRANSFORMATION for the object: ~a~%" object-type)
   (let ((query-result (call-next-method)))
     ;;(format t "GRIPPER LIFT TRANSFORMATION Result is ~a~% for the object: ~a~%" query-result object-type)

--- a/cram_pr2/cram_pr2_pick_place_demo/src/milestone-projection-demo.lisp
+++ b/cram_pr2/cram_pr2_pick_place_demo/src/milestone-projection-demo.lisp
@@ -48,10 +48,11 @@
     ;; ((:breakfast-cereal . ((1.398 1.490 1.2558) (0 0 0.7071 0.7071)))
     ;; (:breakfast-cereal . ((1.1 1.49 1.25) (0 0 0.7071 0.7071)))
     (:milk
-     ;; "iai_fridge_main_middle_level"
-     ;; ((0.10355 0.022 0.094) (0.00939 -0.00636 -0.96978 -0.2437))
-     "iai_fridge_door_shelf1_bottom"
-     ((0.0 -0.05 0.094) (0 0 0 1)))))
+     "iai_fridge_main_middle_level"
+     ((0.10355 -0.055 0.094) (0.00939 -0.00636 -0.96978 -0.2437))
+     ;;"iai_fridge_door_shelf1_bottom"
+     ;; ((0.0 -0.05 0.094) (0 0 0 1))
+     )))
 
 
 (defparameter *delivery-poses*


### PR DESCRIPTION
[Trello Card](https://trello.com/c/9si938Az/350-in-pick-and-place-trajectories-the-lifting-offset-should-be-defined-in-the-gripper-frame-not-the-base-frame)

## New Stuff
It is now possible to define lifting translations for different location types. If a URDF-frame is given its frame will be used to interpret the defined lift translation values, otherwise the robots base frame will be used. This is described in more detailed in the function [man-int:get-lift-transforms-in-base](https://github.com/cram2/cram/pull/195/files#diff-0e7411ecc15354eb47773a237b25e288R286).

## Testing
In `cram-manipulation-interfaces` in `trajectories-tests.lisp` tests were written which test the lifiting offset calculation of different object types in different environments. Moreover, the normal PR2 pick and place demo and the donbot retail demo were run. 