### PR TITLE
Loose Attachments between Objects and Robots after Placing

### DIFF
--- a/cram_3d_world/cram_bullet_reasoning/src/robot-model.lisp
+++ b/cram_3d_world/cram_bullet_reasoning/src/robot-model.lisp
@@ -139,16 +139,23 @@
 (defgeneric (setf link-pose) (new-value robot-object name)
   (:documentation "Sets the pose of a link and all its children"))
 
-
-(defgeneric object-attached (robot-object object)
+(defgeneric object-attached (robot-object object &key loose)
   (:documentation "Returns the list of links `object' has been
   attached to.")
-  (:method ((robot-object robot-object) (object object))
+  (:method ((robot-object robot-object) (object object) &key loose)
     (with-slots (attached-objects) robot-object
-      (values (mapcar #'attachment-link (car (cdr (assoc (name object) attached-objects
-                                                         :test #'equal))))
-              (mapcar #'attachment-grasp (car (cdr (assoc (name object) attached-objects
-                                                          :test #'equal))))))))
+      (values (mapcar #'attachment-link (remove-if-not
+                                         (if loose
+                                             #'attachment-loose
+                                             #'identity)
+                                         (car (cdr (assoc (name object) attached-objects
+                                                          :test #'equal)))))
+              (mapcar #'attachment-grasp (remove-if-not
+                                          (if loose
+                                             #'attachment-loose
+                                             #'identity)
+                                         (car (cdr (assoc (name object) attached-objects
+                                                          :test #'equal)))))))))
 
 (defmethod attach-object ((robot-object robot-object) (obj object)
                           &key link loose grasp &allow-other-keys)

--- a/cram_3d_world/cram_bullet_reasoning_belief_state/src/event-handlers.lisp
+++ b/cram_3d_world/cram_bullet_reasoning_belief_state/src/event-handlers.lisp
@@ -103,18 +103,18 @@ and renames POSE into OLD-POSE."
            (target-desig (cpoe:event-location-designator event))
            (target-on-desig (or (desig:desig-prop-value target-desig :on)
                                 (desig:desig-prop-value target-desig :in)))
-           (urdf-name (desig:desig-prop-value target-on-desig :urdf-name))
-           (object-loose-attached-at-robot-links
-             (car (btr:object-attached (btr:get-robot-object) btr-object :loose T))))
+           (urdf-name (desig:desig-prop-value target-on-desig :urdf-name)))
       ;; If the object is loosely attached to some robot links and the
       ;; target location is not one of these robot links, the
       ;; loose attachment between the robot and the object will be removed.
-      (when (and object-loose-attached-at-robot-links
-                 (not (find (roslisp-utilities:rosify-underscores-lisp-name
-                             urdf-name)
-                            object-loose-attached-at-robot-links
-                            :test #'equalp)))
-        (btr:detach-object (btr:get-robot-object) btr-object))))
+      (multiple-value-bind (object-loose-attached-at-robot-links grasps)
+          (btr:object-attached (btr:get-robot-object) btr-object :loose T)
+        (when (and object-loose-attached-at-robot-links
+                   (not (find (roslisp-utilities:rosify-underscores-lisp-name
+                               urdf-name)
+                              object-loose-attached-at-robot-links
+                              :test #'equalp)))
+          (btr:detach-object (btr:get-robot-object) btr-object)))))
 
   ;; update the designator to get the new location
   (update-object-designator-location

--- a/cram_3d_world/cram_bullet_reasoning_belief_state/src/event-handlers.lisp
+++ b/cram_3d_world/cram_bullet_reasoning_belief_state/src/event-handlers.lisp
@@ -92,6 +92,30 @@ and renames POSE into OLD-POSE."
 
 
 (defmethod cram-occasions-events:on-event btr-belief ((event cpoe:object-location-changed))
+  ;; Remove loose attachment between robot and object,
+  ;; if the object was placed somewhere else, e. g.:
+  ;; the robot has been placing an object on itself
+  ;; and now picked up and placed the object on the table.
+  (when (btr:attached-objects (btr:get-robot-object))
+    (let* ((object-desig (cpoe:event-object-designator event))
+           (object-name (desig:desig-prop-value object-desig :name))
+           (btr-object (btr:object btr:*current-bullet-world* object-name))
+           (target-desig (cpoe:event-location-designator event))
+           (target-on-desig (or (desig:desig-prop-value target-desig :on)
+                                (desig:desig-prop-value target-desig :in)))
+           (urdf-name (desig:desig-prop-value target-on-desig :urdf-name))
+           (object-loose-attached-at-robot-links
+             (car (btr::object-loose-attached (btr:get-robot-object) btr-object))))
+      ;; If the object is loosely attached to some robot links and the
+      ;; target location is not one of these robot links, the
+      ;; loose attachment between the robot and the object will be removed.
+      (when (and object-loose-attached-at-robot-links
+                 (not (find (roslisp-utilities:rosify-underscores-lisp-name
+                             urdf-name)
+                            object-loose-attached-at-robot-links
+                            :test #'equalp)))
+        (btr:detach-object (btr:get-robot-object) btr-object))))
+
   ;; update the designator to get the new location
   (update-object-designator-location
    (cpoe:event-object-designator event)
@@ -215,6 +239,7 @@ If there is no other method with 1 as qualifier, this method will be executed al
                     (remove-if-not
                      (lambda (c) (typep c 'btr:item))
                      (btr:find-objects-in-contact btr:*current-bullet-world* btr-object))))
+
               ;; If a link contacting btr-object was found, btr-object
               ;; will be attached to it
               ;; also, if btr-object is in contact with an item,

--- a/cram_3d_world/cram_bullet_reasoning_belief_state/src/event-handlers.lisp
+++ b/cram_3d_world/cram_bullet_reasoning_belief_state/src/event-handlers.lisp
@@ -105,7 +105,7 @@ and renames POSE into OLD-POSE."
                                 (desig:desig-prop-value target-desig :in)))
            (urdf-name (desig:desig-prop-value target-on-desig :urdf-name))
            (object-loose-attached-at-robot-links
-             (car (btr::object-loose-attached (btr:get-robot-object) btr-object))))
+             (car (btr:object-attached (btr:get-robot-object) btr-object :loose T))))
       ;; If the object is loosely attached to some robot links and the
       ;; target location is not one of these robot links, the
       ;; loose attachment between the robot and the object will be removed.

--- a/cram_demos/cram_object_knowledge/src/household.lisp
+++ b/cram_demos/cram_object_knowledge/src/household.lisp
@@ -160,6 +160,17 @@
   :lift-translation *lift-offset*
   :2nd-lift-translation *lift-offset*)
 
+(man-int:def-object-type-to-gripper-transforms '(:tray) :right :right-side
+  :grasp-translation `(0.0 ,(- *plate-grasp-y-offset*) ,*plate-grasp-z-offset*)
+  :grasp-rot-matrix
+  `((0 -1 0)
+    (,(- (sin *plate-grasp-roll-offset*)) 0 ,(cos *plate-grasp-roll-offset*))
+    (,(- (cos *plate-grasp-roll-offset*)) 0 ,(- (sin *plate-grasp-roll-offset*))))
+  :pregrasp-offsets `(0.0 ,(- *plate-pregrasp-y-offset*) ,*lift-z-offset*)
+  :2nd-pregrasp-offsets `(0.0 ,(- *plate-pregrasp-y-offset*) ,*plate-2nd-pregrasp-z-offset*)
+  :lift-translation *lift-offset*
+  :2nd-lift-translation *lift-offset*)
+
 (man-int:def-object-type-to-gripper-transforms :plate :right :right-side
   :grasp-translation `(0.0 ,(- *plate-grasp-y-offset*) ,*plate-grasp-z-offset*)
   :grasp-rot-matrix


### PR DESCRIPTION
[Trello Card](https://trello.com/c/jd8wE5s1/305-fix-the-attachment-stuff-again-yay-this-time-its-about-loose-attachments)

If the event `cpoe:object-location-updated` was thrown, the event listener in `cram_bullet_reasoning_belief_state` checks if loose attachments between the object (which location was updated) and robot exist. If this is the case and the location in which the object now should be, is not on the robot and is not connected through an attachment with the object, all loose attachments between the object and robot will be removed.  

## Testing

### PR2

In the following code PR2 picks and places as mentioned in the use case of the Trello card, a tray object. To prevent the parking of the arms after each picking-up action, [these code lines](https://github.com/cram2/cram/blob/boxy/cram_common/cram_mobile_pick_place_plans/src/pick-place-plans.lisp#L144) must be commented out.

```
(initialize)
(setf (btr:pose (btr:get-robot-object))
            (cl-tf:make-identity-pose))
(btr-utils:spawn-object :tray-1 :tray :pose '((0.5 0.0 1.0)
                                                   (0 0 0 1.0)))
(urdf-proj:with-simulated-robot
        (let ((?type :tray)
              (?name :tray-1)
              (?arm :right)
              (?grasp :right-side)
              (?tray-tf-in-robot 
                (cl-tf:make-stamped-transform
                 cram-tf:*robot-base-frame*
                 "tray_1"
                 0
                 (cl-tf:make-3d-vector 0.5 0.0 1.0)
                 (cl-tf:make-quaternion 0.0 0.0 0.0 1.0))))
          (exe:perform 
           (desig:an action 
                     (type picking-up)
                     (arm ?arm)
                     (object (desig:an object 
                             (type ?type)
                             (name ?name)
                             (pose ((transform ?tray-tf-in-robot)))))
                     (grasp ?grasp)))))
(urdf-proj:with-simulated-robot
        (let ((?type :tray)
              (?name :tray-1)
              (?arm :left)
              (?grasp :left-side)
              (?tray-tf-in-robot 
                (cl-tf:make-stamped-transform
                 cram-tf:*robot-base-frame*
                 "tray_1"
                 0
                 (cl-tf:make-3d-vector 0.5 0.0 1.0)
                 (cl-tf:make-quaternion 0.0 0.0 0.0 1.0))))
          (exe:perform 
           (desig:an action 
                     (type picking-up)
                     (arm ?arm)
                     (object (desig:an object 
                             (type ?type)
                             (name ?name)
                             (pose ((transform ?tray-tf-in-robot)))))
                     (grasp ?grasp)))))
(urdf-proj:with-simulated-robot
        (let ((?type :tray)
              (?name :tray-1)
              (?arm :right)
              (?grasp :right-side)
              (?tray-pose-in-robot 
                (cl-tf:make-pose-stamped
                 cram-tf:*robot-base-frame*
                 0
                 (cl-tf:make-3d-vector 0.5 0.0 1.0)
                 (cl-tf:make-quaternion 0.0 0.0 0.0 1.0))))
          (exe:perform 
           (desig:an action 
                     (type placing)
                     (arm ?arm)
                     (target (desig:a location
                             (pose ?tray-pose-in-robot)))
                     (grasp ?grasp)))))
(urdf-proj:with-simulated-robot
        (let ((?type :tray)
              (?name :tray-1)
              (?arm :left)
              (?grasp :left-side)
              (?tray-pose-in-robot 
                (cl-tf:make-pose-stamped
                 cram-tf:*robot-base-frame*
                 0
                 (cl-tf:make-3d-vector 0.5 0.0 1.0)
                 (cl-tf:make-quaternion 0.0 0.0 0.0 1.0))))
          (exe:perform 
           (desig:an action 
                     (type placing)
                     (arm ?arm)
                     (target (desig:a location
                             (pose ?tray-pose-in-robot)))
                     (grasp ?grasp)))))

```

### Donbot

To test the second use case as mentioned in the Trello Card, the demo of `cram_donbot_retail_demo` was executed.

```
(urdf-proj:with-simulated-robot
        (demo))
```