### PR TITLE
Added move-base flag parsing for collision check

### DIFF
--- a/cram_3d_world/cram_urdf_projection_reasoning/src/check-collisions.lisp
+++ b/cram_3d_world/cram_urdf_projection_reasoning/src/check-collisions.lisp
@@ -153,7 +153,23 @@ Store found pose into designator or throw error if good pose not found."
                         (right-lift-poses
                           (desig:desig-prop-value pick-up-action-referenced :right-lift-poses))
                         (object-name
-                          (desig:desig-prop-value object-designator :name)))
+                          (desig:desig-prop-value object-designator :name))
+                        (move-base
+                          (cut:var-value '?move-base
+                                         (cut:lazy-car
+                                          (prolog:prolog
+                                           `(-> (and (or
+                                                      (spec:property ,object-designator
+                                                                     (:location ?location-desig))
+                                                      (spec:property ,pick-up-action-referenced
+                                                                     (:location ?location-desig)))
+                                                     (spec:property ?location-desig
+                                                                    (:on ?on-object-desig))
+                                                     (spec:property ?on-object-desig
+                                                                    (:name ?robot-name))
+                                                     (rob-int:robot ?robot-name))
+                                                (equal ?move-base nil)
+                                                (equal ?move-base t)))))))
 
                    (urdf-proj::gripper-action gripper-opening arm)
 
@@ -170,7 +186,7 @@ Store found pose into designator or throw error if good pose not found."
                           (cut:equalize-two-list-lengths left-poses right-poses)
                         (dotimes (i (length left-poses))
                           (urdf-proj::move-tcp (nth i left-poses) (nth i right-poses)
-                                               :allow-all)
+                                               :allow-al nil nil nil move-base)
                           (unless (< (abs urdf-proj::*debug-short-sleep-duration*) 0.0001)
                             (cpl:sleep urdf-proj::*debug-short-sleep-duration*))
                           (when (urdf-proj::perform-collision-check
@@ -251,7 +267,23 @@ Store found pose into designator or throw error if good pose not found."
                         (right-retract-poses
                           (desig:desig-prop-value placing-action-referenced :right-retract-poses))
                         (object-name
-                          (desig:desig-prop-value object-designator :name)))
+                          (desig:desig-prop-value object-designator :name))
+                        (move-base
+                          (cut:var-value '?move-base
+                                         (cut:lazy-car
+                                          (prolog:prolog
+                                           `(-> (and (or
+                                                      (spec:property ,object-designator
+                                                                     (:location ?location-desig))
+                                                      (spec:property ,placing-action-desig
+                                                                     (:target ?location-desig)))
+                                                     (spec:property ?location-desig
+                                                                    (:on ?on-object-desig))
+                                                     (spec:property ?on-object-desig
+                                                                    (:name ?robot-name))
+                                                     (rob-int:robot ?robot-name))
+                                                (equal ?move-base nil)
+                                                (equal ?move-base t)))))))
 
                    (urdf-proj::gripper-action :open arm)
 
@@ -265,7 +297,7 @@ Store found pose into designator or throw error if good pose not found."
                           (cut:equalize-two-list-lengths left-poses right-poses)
                         (dotimes (i (length left-poses))
                           (urdf-proj::move-tcp (nth i left-poses) (nth i right-poses)
-                                               :allow-all)
+                                               :allow-all nil nil nil move-base)
                           (unless (< (abs urdf-proj:*debug-short-sleep-duration*) 0.0001)
                             (cpl:sleep urdf-proj:*debug-short-sleep-duration*))
                           (when (or


### PR DESCRIPTION
[trello](https://trello.com/c/LDaau9Zq/366-in-check-collisions-of-picking-and-placing-actions-move-base-flag-is-not-being-considered)

Parsing move base flag for picking and placing actions to nil if the target is on the robot.

Note: I wasn't able to fully test this because I didn't manage to get donbot demo working on my system. I have only tested it discretely with my own action designators and explicit calls and would need some input in the actual scenario