### PR TITLE
Costmap Visualizations now Flat

### DIFF
--- a/cram_3d_world/cl_bullet_vis/src/math-function-visualization.lisp
+++ b/cram_3d_world/cl_bullet_vis/src/math-function-visualization.lisp
@@ -58,8 +58,7 @@
                      (let ((new-value (funcall fun x y)))
                        (setf (gethash (list x y) value-points)
                              (when (numberp new-value)
-                               (cl-transforms:make-3d-vector x y
-                                                             new-value))))))))
+                               (cl-transforms:make-3d-vector x y new-value))))))))
            (get-height (x y)
              (with-slots (height-fun) obj
                (multiple-value-bind (old-value found?)

--- a/cram_3d_world/cram_bullet_reasoning/src/debug-window.lisp
+++ b/cram_3d_world/cram_bullet_reasoning/src/debug-window.lisp
@@ -36,7 +36,7 @@
 (defvar *current-costmap-sample* nil "A red sphere for visualizing costmap samples.")
 (defvar *vis-axes* nil "An associative list of ((ID . (X Y Z)) ...) couples,
 storing axes of a coordinate frame for visualizing poses.")
-(defparameter *costmap-z* 0.0)
+(defparameter *costmap-z* 0.02)
 (defparameter *costmap-tilt* (cl-transforms:make-quaternion 0 0 0 1))
 
 (defun add-debug-window (world)
@@ -107,8 +107,11 @@ storing axes of a coordinate frame for visualizing poses.")
         (declare (type cma:double-matrix map-array))
         (flet ((costmap-function (x y)
                  (let ((val (/ (location-costmap:get-map-value costmap x y) max-val)))
-                   (when (> val location-costmap:*costmap-valid-solution-threshold*)
-                     val))))
+                   (when (> val location-costmap:*costmap-valid-solution-threshold*) 
+                     val)))
+               (costmap-height-function (x y)
+                 (let ((val (location-costmap:get-map-height costmap x y)))
+                   (+ val *costmap-z*))))
           (setf *current-costmap-function*
                 (make-instance 'math-function-object
                   :width (location-costmap:grid-width costmap)
@@ -123,6 +126,7 @@ storing axes of a coordinate frame for visualizing poses.")
                           *costmap-z*)
                          *costmap-tilt*)
                   :function #'costmap-function
+                  :height-function #'costmap-height-function
                   :step-size (location-costmap:resolution costmap)))))
       (when *debug-window*
         (push *current-costmap-function* (gl-objects *debug-window*))))))

--- a/cram_common/cram_location_costmap/src/location-costmap.lisp
+++ b/cram_common/cram_location_costmap/src/location-costmap.lisp
@@ -190,6 +190,9 @@ calls the generator functions and runs normalization."
        :orientation-generators (mapcan (compose #'copy-list #'orientation-generators)
                                        (cons cm-1 costmaps))))))
 
+(defmethod get-map-height ((map location-costmap) x y)
+  (generate-height map x y))
+
 (defun generate-height (map x y &optional (default 0.0d0))
   (or
    (when (height-generators map)

--- a/cram_common/cram_location_costmap/src/package.lisp
+++ b/cram_common/cram_location_costmap/src/package.lisp
@@ -77,6 +77,7 @@
            #:on-visualize-costmap
            #:on-visualize-costmap-sample
            #:get-map-value
+           #:get-map-height
            #:no-cost-functions-registered
            #:register-cost-function
            #:register-height-generator


### PR DESCRIPTION
[Trello Card](https://trello.com/c/VqwA66YK/354-make-the-costmap-visualizations-flat-and-take-the-height-from-the-height-generator-value-for-a-random-x-y-include-a-little-z-off)

### Tests

Tested with the cram package `cram_pr2_pick_and_place_demo`.