### PR TITLE
Fix distance clipping in goals

### DIFF
--- a/cram_3d_world/cram_urdf_environment_manipulation/src/environment.lisp
+++ b/cram_3d_world/cram_urdf_environment_manipulation/src/environment.lisp
@@ -398,8 +398,10 @@ Using a default (1 0 0)."
       (:closing
        (- (- distance state))))))
 
+;; Important note: This assumes a relative distance, because the trajectory calculations
+;; were implemented in a relative manner.
 (defun clip-distance (container-name btr-environment distance action-type)
-  "Return a distance that stays inside the joint's limits."
+  "Return a relative distance that stays inside the joint's limits."
   (declare (type (or string symbol) container-name)
            (type keyword btr-environment)
            (type number distance)


### PR DESCRIPTION
Add distance clipping to the absolute distances given to container-state goal.
Change handling of :open distance, so it is just the opposite of :closed. As in "is the joint at a state more than <delta> greater than it's lower-limit?".

Also adds a small note at another point in the code to point out that it handles relative distances instead of absolute ones. If this is unwanted the commit can be easily omitted.