### PR TITLE
Fixing reset behavior for location designators

### DIFF
--- a/cram_3d_world/cram_fetch_deliver_plans/src/fetch-and-deliver-plans.lisp
+++ b/cram_3d_world/cram_fetch_deliver_plans/src/fetch-and-deliver-plans.lisp
@@ -235,7 +235,7 @@ retries with different search location or robot base location."
                  outer-search-location-retries
                  (:error-object-or-string e
                   :warning-namespace (fd-plans search-for-object)
-                  :reset-designators (list ?robot-location ?search-location)
+                  :reset-designators (list ?robot-location)
                   :rethrow-failure 'common-fail:searching-failed
                   :distance-threshold 0.1)
                (roslisp:ros-warn (fd-plans search-for-object)

--- a/cram_3d_world/cram_fetch_deliver_plans/src/fetch-and-deliver-plans.lisp
+++ b/cram_3d_world/cram_fetch_deliver_plans/src/fetch-and-deliver-plans.lisp
@@ -378,7 +378,7 @@ and using the grasp and arm specified in `pick-up-action' (if not NIL)."
                        (desig:when (eql object-hand :right)
                          (right-configuration hand-over))
                        (goal ?goal)))
-            (desig:reset ?look-location)))
+            (setf ?look-location (desig:reset ?look-location))))
 
         (let (;; (?goal `(cpoe:looking-at ,?look-location))
               )
@@ -509,8 +509,8 @@ and using the grasp and arm specified in `pick-up-action' (if not NIL)."
 and the robot should stand at `?target-robot-location' when placing the object.
 If a failure happens, try a different `?target-location' or `?target-robot-location'."
 
-  (desig:reset ?target-location)
-  (desig:reset ?target-robot-location)
+  (setf ?target-location (desig:reset ?target-location))
+  (setf ?target-robot-location (desig:reset ?target-robot-location))
 
   ;; Reference the `?target-location' to see if that works at all
   ;; If not, delivering is impossible so throw a OBJECT-UNDERLIVERABLE failure
@@ -565,6 +565,9 @@ If a failure happens, try a different `?target-location' or `?target-robot-locat
                   (((or common-fail:looking-high-level-failure
                         common-fail:object-unreachable
                         common-fail:high-level-failure) (e)
+                     (roslisp:ros-warn (fd-plans deliver)
+                                       "target-location-retries ~A~%"
+                                       (cpl:get-counter target-location-retries))
                      (common-fail:retry-with-loc-designator-solutions
                          ?target-location
                          target-location-retries
@@ -591,7 +594,7 @@ If a failure happens, try a different `?target-location' or `?target-robot-locat
                                (desig:when (eql target-hand :right)
                                  (right-configuration hand-over))
                                (goal ?goal)))
-                    (desig:reset ?target-location)))
+                    (setf ?target-location (desig:reset ?target-location))))
 
                 ;; look
                 (let (;; (?goal `(cpoe:looking-at ,?target-location))

--- a/cram_3d_world/cram_fetch_deliver_plans/tests/fetching-tests.lisp
+++ b/cram_3d_world/cram_fetch_deliver_plans/tests/fetching-tests.lisp
@@ -100,7 +100,7 @@
                   (robot-location (a location
                                      (poses (*valid-robot-pose-towards-island-near-wall*))))))))
   (assert-equal 1 (get-error-count-for-error 'common-fail:fetching-failed))
-  (assert-equal 5 (get-error-count-for-error 'common-fail:perception-object-not-found)))
+  (assert-equal 2 (get-error-count-for-error 'common-fail:perception-object-not-found)))
 
 
 (define-test object-reached-on-second-robot-location-fetch-test
@@ -142,7 +142,7 @@
                                     (poses (*valid-robot-pose-towards-sink-area-surface*)))))))
   (assert-equal 0 (get-error-count-for-error 'common-fail:fetching-failed))
   (assert-equal 1 (get-error-count-for-error 'common-fail:object-unreachable))
-  (assert-equal 4 (get-error-count-for-error 'common-fail:manipulation-goal-in-collision)))
+  (assert-equal 5 (get-error-count-for-error 'common-fail:manipulation-goal-in-collision)))
 
 
 (define-test object-unreachable-with-only-unreachable-arm-fetch-test
@@ -186,7 +186,7 @@
                                     (poses (*valid-robot-pose-towards-island-near-wall*
                                             *valid-robot-pose-towards-sink-area-surface*)))))))
   ;; Can't find in the first location
-  (assert-equal 5 (get-error-count-for-error 'common-fail:perception-object-not-found)))
+  (assert-equal 2 (get-error-count-for-error 'common-fail:perception-object-not-found)))
 
 
 (define-test navigation-pose-invalid-before-perception-fetch-test
@@ -236,5 +236,5 @@
   (assert-equal 1 (get-error-count-for-error 'common-fail:fetching-failed))
   (assert-equal 4 (get-error-count-for-error 'common-fail:manipulation-low-level-failure))
   (assert-equal 2 (get-error-count-for-error 'common-fail:object-unreachable))
-  (assert-equal 1 (get-error-count-for-error 'common-fail:navigation-goal-in-collision))
-  (assert-equal 1 (get-error-count-for-error 'common-fail:navigation-pose-unreachable)))
+  (assert-equal 50 (get-error-count-for-error 'common-fail:navigation-goal-in-collision))
+  (assert-equal 50 (get-error-count-for-error 'common-fail:navigation-pose-unreachable)))

--- a/cram_3d_world/cram_fetch_deliver_plans/tests/searching-tests.lisp
+++ b/cram_3d_world/cram_fetch_deliver_plans/tests/searching-tests.lisp
@@ -30,10 +30,11 @@
 (in-package :fd-plans-tests)
 
 (defparameter *searching-tests* '(object-can-be-found-no-errors-search-test
-                                 object-can-be-found-in-second-try-search-test
-                                 object-occluded-from-view-search-test
-                                 unreachable-location-search-test
-                                 initially-unreachable-location-search-test))
+                                  object-can-be-found-in-second-try-search-test
+                                  object-occluded-from-view-search-test
+                                  unreachable-location-search-test
+                                  initially-unreachable-location-search-test
+                                  object-can-be-found-after-visibility-designator-error-search-test))
 
 (define-test object-can-be-found-no-errors-search-test
   (init-projection)
@@ -69,7 +70,7 @@
                  (robot-location (a location (poses (*valid-robot-pose-towards-island*)))))))
   (assert-equal 0 (get-error-count-for-error 'common-fail:searching-failed))
   (assert-equal 0 (get-error-count-for-error 'common-fail:object-nowhere-to-be-found))
-  (assert-equal 5 (get-error-count-for-error 'common-fail:perception-object-not-found)))
+  (assert-equal 2 (get-error-count-for-error 'common-fail:perception-object-not-found)))
 
 
 (define-test object-occluded-from-view-search-test

--- a/cram_3d_world/cram_fetch_deliver_plans/tests/searching-tests.lisp
+++ b/cram_3d_world/cram_fetch_deliver_plans/tests/searching-tests.lisp
@@ -132,3 +132,15 @@
   (assert-equal 1 (get-error-count-for-error 'common-fail:navigation-pose-unreachable)))
 
 
+(define-test object-can-be-found-after-visibility-designator-error-search-test
+  (init-projection)
+  (spawn-object *valid-location-on-island* :bowl)
+  (urdf-proj:with-simulated-robot
+    (perform (an action
+                 (type searching)
+                 (object (an object
+                             (type bowl)
+                             (location (a location
+                                          (poses (*valid-location-inside-fridge*
+                                                  *valid-location-on-island*)))))))))
+  (assert-equal 1 (get-error-count-for-error 'common-fail:navigation-goal-in-collision)))

--- a/cram_3d_world/cram_fetch_deliver_plans/tests/utils.lisp
+++ b/cram_3d_world/cram_fetch_deliver_plans/tests/utils.lisp
@@ -151,6 +151,12 @@
 (defparameter *valid-location-on-sink-area-surface-near-oven*
   (make-pose-stamped '((1.54 1.1 0.9) (0 0 0 1))))
 
+(defparameter *valid-location-inside-fridge*
+  (make-pose-stamped '((1.48 -1.16 0.55) (0 0 0 1))))
+
+(defparameter *invalid-location-outside-map*
+  (make-pose-stamped '((2.8 0.71 0.9) (0 0 0 1))))
+
 ;;;;;;;;;;;;; Robot Poses ;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defparameter *valid-robot-pose-towards-island*

--- a/cram_3d_world/cram_fetch_deliver_plans/tests/utils.lisp
+++ b/cram_3d_world/cram_fetch_deliver_plans/tests/utils.lisp
@@ -99,6 +99,46 @@
         0
         (cdr (assoc error-keyword *error-counter-look-up*)))))
 
+(defun make-restricted-area-cost-function ()
+  (lambda (x y)
+    (if (> x 1.2)
+        0.0
+        (if (and (> x 0.5) (> y -1.5) (< y 2.0))
+            1.0
+            (if (and (> x 0.0) (> y -1.5) (< y 1.0))
+                1.0
+                (if (and (> x -1.5) (> y -1.5) (< y 2.5))
+                    1.0
+                    (if (and (> x -4.0) (> y -1.0) (< y 1.0))
+                        1.0
+                        0.0)))))))
+
+(defmethod location-costmap:costmap-generator-name->score ((name (eql 'restricted-area))) 5)
+
+(def-fact-group demo-costmap (location-costmap:desig-costmap)
+  (<- (location-costmap:desig-costmap ?designator ?costmap)
+    (or (rob-int:visibility-designator ?designator)
+        (rob-int:reachability-designator ?designator))
+    ;; make sure that the location is not on the robot itself
+    ;; if it is, don't generate a costmap
+    (once (or (and (desig:desig-prop ?designator (:object ?some-object))
+                   (desig:current-designator ?some-object ?object)
+                   (lisp-fun man-int:get-object-pose-in-map ?object ?to-reach-pose)
+                   (lisp-pred identity ?to-reach-pose)
+                   (-> (desig:desig-prop ?object (:location ?loc))
+                       (not (man-int:location-always-reachable ?loc))
+                       (true)))
+              (and (desig:desig-prop ?designator (:location ?some-location))
+                   (desig:current-designator ?some-location ?location)
+                   ;; if the location is on the robot itself,
+                   ;; don't use the costmap
+                   (not (man-int:location-always-reachable ?location)))))
+    (location-costmap:costmap ?costmap)
+    (location-costmap:costmap-add-function
+     restricted-area
+     (make-restricted-area-cost-function)
+     ?costmap)))
+
 ;;;;;;;;;;;; Object Poses ;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defparameter *valid-location-on-island*

--- a/cram_common/cram_common_failures/src/failure-handling-strategies.lisp
+++ b/cram_common/cram_common_failures/src/failure-handling-strategies.lisp
@@ -55,7 +55,7 @@ using the `rethrow-failure' key."
                (roslisp:ros-warn ,warning-namespace "Retrying.~%")
                (setf ,iterator-desig next-solution-element)
                (loop for designator in ,reset-designators
-                     do (desig:reset designator))
+                     do (setf designator (desig:reset designator)))
                ,@body
                (cpl:retry))
              (roslisp:ros-warn ,warning-namespace "No samples left.~%"))))
@@ -136,7 +136,7 @@ the previous solution (the default is 0.05m)."
                (roslisp:ros-warn ,warning-namespace "Retrying.~%")
                (setf ,location-desig next-solution-element)
                (loop for designator in ,reset-designators
-                     do (desig:reset designator))
+                     do (setf designator (desig:reset designator)))
                ,@body
                (cpl:retry))
              (roslisp:ros-warn ,warning-namespace "No samples left.~%"))))

--- a/cram_common/cram_location_costmap/src/designator-integration.lisp
+++ b/cram_common/cram_location_costmap/src/designator-integration.lisp
@@ -38,6 +38,9 @@
 (defun reset-costmap-cache ()
   (setf *costmap-cache* (tg:make-weak-hash-table :test 'eq :weakness :key)))
 
+(defmethod reset :after ((desig location-designator))
+  (remhash (first-desig desig) *costmap-cache*))
+
 (defun get-cached-costmap (desig)
   (let ((first-designator (first-desig desig)))
     (or (gethash first-designator *costmap-cache*)

--- a/cram_core/cram_designators/src/cram-designators/designator-protocol.lisp
+++ b/cram_core/cram_designators/src/cram-designators/designator-protocol.lisp
@@ -126,15 +126,16 @@
   (:method ((solution-1 array) (solution-2 array))
     (equalp solution-1 solution-2)))
 
-(defun reset (desig)
-  "Resets the designator by deleting all associated solutions.
-Used for recalculating a designator when its dependent designator got updated.
-The actual implementation creates a copy of the designator, such that only
-the description is preserved. The returned designator is equated to the input one,
-in case one would want to get back to the old one through the equated designator chain."
-  (let ((desig-copy (copy-designator desig)))
-    (equate desig desig-copy)
-    (setf desig desig-copy)))
+(defgeneric reset (desig)
+  (:documentation "Resets the designator by deleting all associated solutions.
+  Used for recalculating a designator when its dependent designator got updated.
+  The actual implementation creates a copy of the designator, such that only
+  the description is preserved. The returned designator is equated to the input one,
+  in case one would want to get back to the old one through the equated designator chain.")
+  (:method (desig)
+    (let ((desig-copy (copy-designator desig)))
+      (equate desig desig-copy)
+      (setf desig desig-copy))))
 
 (defvar *designator-pprint-description* t
   "If set to T, DESIGNATOR objects will be pretty printed with their description.")


### PR DESCRIPTION
### Changes
 - Made `reset` a generic function
 - Made an `:after` clause for `reset` specifically for location designators which clears the cached value from the hash table
 - Updated the failure-strategy methods to set the variable after resetting
 - In fetch and deliver plans, removing `?search-location` from reset list because it's not needed anymore
 - Added a new test to recover with the visibility designator error

## Note
 Haven't added a test for reachability since the placing has a lot more unpredictables since we're relying on a costmap. So couldn't get a determinitstic test yet.