### PR TITLE
Fix trajectory hacks

### DIFF
--- a/cram_3d_world/cram_urdf_environment_manipulation/src/trajectories.lisp
+++ b/cram_3d_world/cram_urdf_environment_manipulation/src/trajectories.lisp
@@ -118,8 +118,8 @@ The parameters are analog to the ones of `get-action-trajectory'."
        (make-prismatic-trajectory object-transform arm action-type grasp-pose opening-distance))
       (:container-revolute
        (make-revolute-trajectory object-transform arm action-type grasp-pose opening-distance
-                                 (get-revolute-axis object-name)
-                                 (get-revolute-invert object-name)))
+                                 (get-revolute-axis object-name object-environment)
+                                 (get-revolute-invert object-name object-environment)))
       (T (error "Unsupported container-type: ~a." object-type)))))
 
 
@@ -319,15 +319,15 @@ So normally (0 1 0) or (0 0 1).
         0
         0))))))
 
-(defun get-revolute-axis (object-name)
+(defun get-revolute-axis (object-name object-environment)
   (cl-tf:rotate
    (cl-tf:rotation
     (cl-urdf:origin
      (cl-urdf:from-joint
-      (get-handle-link object-name :iai-kitchen))))
+      (get-handle-link object-name object-environment))))
    (cl-tf:make-3d-vector 0 0 1)))
 
-(defun get-revolute-invert (object-name)
+(defun get-revolute-invert (object-name object-environment)
   (let ((name-exception
           (alexandria:switch ((roslisp-utilities:rosify-underscores-lisp-name
                                object-name)

--- a/cram_3d_world/cram_urdf_environment_manipulation/src/trajectories.lisp
+++ b/cram_3d_world/cram_urdf_environment_manipulation/src/trajectories.lisp
@@ -256,7 +256,7 @@ around `axis' by `angle-max' in steps of 0.1 rad."
 `object-name' is the name of a container in the `btr-environment'.
 `arm' denotes which arm's gripper should be used (eg. :left or :right).
 `handle-axis' is the axis on which the handle lies when looked at from the front in form of a vector.
-So normally (1 0 0) or (0 0 1).
+So normally (0 1 0) or (0 0 1).
 `btr-environment' is the name of the environment in which the container is located (eg. :KITCHEN)."
   (declare (type (or string symbol) object-name)
            (type keyword arm)
@@ -320,17 +320,12 @@ So normally (1 0 0) or (0 0 1).
         0))))))
 
 (defun get-revolute-axis (object-name)
-  (let ((name-exception
-          (alexandria:switch ((roslisp-utilities:rosify-underscores-lisp-name
-                               object-name)
-                              :test 'equal)
-            ("oven_area_oven_main"
-             (cl-transforms:make-3d-vector 0 1 0))
-            ("sink_area_dish_washer_main"
-             (cl-transforms:make-3d-vector 0 1 0)))))
-    (if name-exception
-        name-exception
-        (cl-transforms:make-3d-vector 0 0 1))))
+  (cl-tf:rotate
+   (cl-tf:rotation
+    (cl-urdf:origin
+     (cl-urdf:from-joint
+      (get-handle-link object-name :iai-kitchen))))
+   (cl-tf:make-3d-vector 0 0 1)))
 
 (defun get-revolute-invert (object-name)
   (let ((name-exception


### PR DESCRIPTION
Instead of a name-based hack the parameters for keeping the gripper rotated correctly are inferred from the URDF. 
Also a bad implementation was exchanged with an easy quaternion multiplication.