### PR TITLE
[Spatial-CM] Fix orientation for support aligned for spoon

### DIFF
--- a/cram_3d_world/cram_btr_spatial_relations_costmap/cram-btr-spatial-relations-costmap-tests.asd
+++ b/cram_3d_world/cram_btr_spatial_relations_costmap/cram-btr-spatial-relations-costmap-tests.asd
@@ -1,0 +1,68 @@
+;;; Copyright (c) 2020, Amar Fayaz <amar@uni-bremen.de>
+;;; All rights reserved.
+;;;
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions are met:
+;;;
+;;;     * Redistributions of source code must retain the above copyright
+;;;       notice, this list of conditions and the following disclaimer.
+;;;     * Redistributions in binary form must reproduce the above copyright
+;;;       notice, this list of conditions and the following disclaimer in the
+;;;       documentation and/or other materials provided with the distribution.
+;;;     * Neither the name of the Intelligent Autonomous Systems Group/
+;;;       Technische Universitaet Muenchen nor the names of its contributors
+;;;       may be used to endorse or promote products derived from this software
+;;;       without specific prior written permission.
+;;;
+;;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+;;; LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+;;; CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+;;; SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+;;; CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+;;; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+;;; POSSIBILITY OF SUCH DAMAGE.
+
+(defsystem cram-btr-spatial-relations-costmap-tests
+  :author "Amar Fayaz"
+  :license "BSD"
+  :depends-on (roslisp
+               lisp-unit
+
+               cram-language
+               cram-executive
+               cram-designators
+               cram-prolog
+               cram-projection
+               cram-occasions-events
+
+               cram-common-failures
+               cram-mobile-pick-place-plans
+               cram-object-knowledge
+
+               cram-physics-utils     ; for reading "package://" paths
+               cl-bullet ; for handling BOUNDING-BOX datastructures
+               cram-bullet-reasoning
+               cram-bullet-reasoning-belief-state
+               cram-bullet-reasoning-utilities
+
+               cram-location-costmap
+               cram-btr-visibility-costmap
+               cram-btr-spatial-relations-costmap
+               cram-robot-pose-gaussian-costmap
+               cram-occupancy-grid-costmap
+
+               cram-urdf-projection      ; for with-simulated-robot
+               cram-urdf-projection-reasoning ; to set projection reasoning to T
+               cram-fetch-deliver-plans
+               cram-urdf-environment-manipulation
+
+               cram-pr2-description)
+  :components
+  ((:module "tests"
+    :components
+    ((:file "package")
+     (:file "orientation-tests" :depends-on ("package"))))))

--- a/cram_3d_world/cram_btr_spatial_relations_costmap/src/cost-functions.lisp
+++ b/cram_3d_world/cram_btr_spatial_relations_costmap/src/cost-functions.lisp
@@ -630,11 +630,7 @@ if it is on the sign side of the axis. "
          ;; This is only correct if supp-obj is rotated only around Z axis, i.e.
          ;; it is parallel to the floor
          (supp-angle
-           (* 2 (acos (cl-transforms:w (cl-transforms:orientation supp-obj-pose))))))
-    ;; acos only gives values between 0 and pi
-    ;; checks the sign of the cos to see what sign the angle should have
-    (when (< (cl-transforms:z (cl-transforms:orientation supp-obj-pose)) 0)
-      (setf supp-angle (- (* 2 pi) supp-angle)))
+           (cram-tf:angle-around-map-z (cl-transforms:orientation supp-obj-pose))))
     (+ supp-angle angle-in-supp)))
 
 (defun make-supporting-obj-aligned-orientations-generator (supp-obj-dims supp-obj-pose

--- a/cram_3d_world/cram_btr_spatial_relations_costmap/tests/orientation-tests.lisp
+++ b/cram_3d_world/cram_btr_spatial_relations_costmap/tests/orientation-tests.lisp
@@ -1,0 +1,98 @@
+;;; Copyright (c) 2020, Amar Fayaz <amar@uni-bremen.de>
+;;; All rights reserved.
+;;;
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions are met:
+;;;
+;;;     * Redistributions of source code must retain the above copyright
+;;;       notice, this list of conditions and the following disclaimer.
+;;;     * Redistributions in binary form must reproduce the above copyright
+;;;       notice, this list of conditions and the following disclaimer in the
+;;;       documentation and/or other materials provided with the distribution.
+;;;     * Neither the name of the Intelligent Autonomous Systems Group/
+;;;       Technische Universitaet Muenchen nor the names of its contributors
+;;;       may be used to endorse or promote products derived from this software
+;;;       without specific prior written permission.
+;;;
+;;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+;;; LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+;;; CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+;;; SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+;;; CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+;;; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+;;; POSSIBILITY OF SUCH DAMAGE.
+
+(in-package :spatial-cm-tests)
+
+(defun setup-test ()
+  (coe:clear-belief)
+  (setf cram-tf:*tf-default-timeout* 2.0)
+  (setf prolog:*break-on-lisp-errors* t)
+  (setf proj-reasoning::*projection-reasoning-enabled* nil)
+
+  (btr-utils:kill-all-objects)
+  (btr:add-objects-to-mesh-list "cram_pr2_pick_place_demo"))
+
+(defun spawn-object (pose object-type)
+  (btr-utils:spawn-object
+   (intern (format nil "~a-1" object-type) :keyword)
+   object-type
+   :pose pose
+   :mass 0.0)
+  (btr:simulate btr:*current-bullet-world* 100))
+
+(defun make-pose-stamped (pose-list)
+  (cl-transforms-stamped:make-pose-stamped
+   "map" 0.0
+   (apply #'cl-transforms:make-3d-vector (first pose-list))
+   (apply #'cl-transforms:make-quaternion (second pose-list))))
+
+
+(define-test check-spoon-orientation-and-height-on-dining-table
+  (setup-test)
+  ;; bowl pose is on the dining table
+  (let ((bowl-pose (make-pose-stamped '((-3.368202972412109d0
+                                         -0.15089993476867675d0
+                                         0.7991479237874349d0)
+                                        (3.7803240502398694d-6
+                                         -5.186260023037903d-5
+                                         0.9513682126998901d0
+                                         0.30805596709251404d0))))
+        ;; Spoon just needs to exist, the pose doesn't matter
+        (spoon-pose (make-pose-stamped '((0 0 0) (0 0 0 1)))))
+    (spawn-object bowl-pose :bowl)
+    (spawn-object spoon-pose :spoon)
+    (let* ((?other-object-designator
+             (desig:an object
+                       (type bowl)
+                       (location (desig:a location
+                                          (on (desig:an object
+                                                        (type counter-top)
+                                                        (urdf-name dining-area-jokkmokk-table-main)
+                                                        (part-of iai-kitchen)))
+                                          (for (desig:an object (type bowl)))
+                                          (side right)
+                                          (context table-setting)
+                                          (object-count 2)))))
+           (location-right-of-bowl (desig:reference (desig:a location
+                                                             (right-of ?other-object-designator)
+                                                             (near ?other-object-designator)
+                                                             (for (desig:an object (type spoon)))
+                                                             (orientation support-aligned))))
+           (angle-for-spoon (cram-tf:angle-around-map-z
+                             (cl-transforms:orientation location-right-of-bowl)))
+           (height-for-spoon (cl-transforms:z (cl-transforms:origin location-right-of-bowl)))
+           (height-of-dining-table (btr-spatial-cm::get-rigid-body-aabb-top-z
+                                    (btr:rigid-body
+                                     (btr:object btr:*current-bullet-world* :iai-kitchen)
+                                     (btr::make-rigid-body-name
+                                      (string-upcase :iai-kitchen)
+                                      (roslisp-utilities:rosify-underscores-lisp-name
+                                       'dining-area-jokkmokk-table-main))))))
+
+      (assert-true (< (- height-for-spoon height-of-dining-table) 0.05))
+      (assert-true (< (abs (- 1.5708 angle-for-spoon)) 0.02))))) ;; ~1 degrees

--- a/cram_3d_world/cram_btr_spatial_relations_costmap/tests/package.lisp
+++ b/cram_3d_world/cram_btr_spatial_relations_costmap/tests/package.lisp
@@ -1,0 +1,34 @@
+;;; Copyright (c) 2020, Amar Fayaz <amar@uni-bremen.de>
+;;; All rights reserved.
+;;; 
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions are met:
+;;; 
+;;;     * Redistributions of source code must retain the above copyright
+;;;       notice, this list of conditions and the following disclaimer.
+;;;     * Redistributions in binary form must reproduce the above copyright
+;;;       notice, this list of conditions and the following disclaimer in the
+;;;       documentation and/or other materials provided with the distribution.
+;;;     * Neither the name of the Intelligent Autonomous Systems Group/
+;;;       Technische Universitaet Muenchen nor the names of its contributors 
+;;;       may be used to endorse or promote products derived from this software 
+;;;       without specific prior written permission.
+;;; 
+;;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+;;; LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+;;; CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+;;; SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+;;; CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+;;; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+;;; POSSIBILITY OF SUCH DAMAGE.
+
+(in-package :cl-user)
+
+(defpackage :cram-btr-spatial-relations-costmap-tests
+  (:nicknames :spatial-cm-tests)
+  (:use #:common-lisp #:lisp-unit #:btr)
+  (:export))


### PR DESCRIPTION
### Changes
1. Added a unit test to check the orientation and height spoon on dining table support aligned
2. `cram-tf:angle-around-map-z` does the inverse calculation better than the current way of accounting for the object pose to check support aligned. (checked the new solution with kitchen island, dining table and sink area surface)