### PR TITLE
Fixing the missing side keywords for location designator

### DIFF
--- a/cram_core/cram_designators/src/cram-designators/designator-protocol.lisp
+++ b/cram_core/cram_designators/src/cram-designators/designator-protocol.lisp
@@ -314,8 +314,10 @@ description will be dominant in this relation."
 (defun merge-desig-descriptions (designator new-description)
   "Returns the merge of the description of `designator' with `new-description'.
  The new description will be dominant in this relation."
-  (reduce (rcurry (flip #'adjoin) :key #'car)
-          (description designator) :initial-value new-description))
+  (append (reduce (alexandria:rcurry (cut:flip #'remove) :key #'car)
+                  (mapcar #'car new-description)
+                  :initial-value (description designator))
+          new-description))
 
 (defun extend-designator-properties (designator property-extension)
   "Extends (without merging) the properties of `designator'


### PR DESCRIPTION
### Problem
Using 2 side keywords in a location designator for a plan would only use one of the side keywords

### Cause
The method `desig:merge-desig-descriptions` used adjoin and reduce functions together which caused the adjoin to be called for the elements in the same designator description swallowing any use of duplicate keywords, even if the values were different. Since this was called in the `desig:reset` and it being called in the plans caused the side keywords to be only used once after a reset.

### Fix
Moved from the use of adjoin to `remove`. Now all the key-value pair from the priority description `new-description` is used to remove the key-value pairs from the non-priority description `(description designator)` and finally append it to the new-description to form the final merged description. Thus the priority functionality remains the same and there will be no comparison between the keys within the same description. Final behavior: Keep all the items from the priority description and keep the items from the non-priority description where the key does not exist in the priority description