### PR TITLE
Consider indirect attachements between items in btr:robot-attached-objects-in-collision

### DIFF
--- a/cram_3d_world/cram_bullet_reasoning/src/items.lisp
+++ b/cram_3d_world/cram_bullet_reasoning/src/items.lisp
@@ -265,51 +265,44 @@ it is possible to change the pose of its attachments when its pose changes."
                 (setf already-moved '()))))
         (call-next-method))))
 
-(let ((checked-attached-objects-of '())
-      (checked-all-attachments T))
+(flet ((object-directly-attached-p (object other-object)
+         (with-slots (attached-objects) object
+           (find (btr:name other-object)
+                 (mapcar #'car attached-objects)
+                 :test #'equalp))))
   
-  (flet ((already-checked-object-p (name)
-           (some (lambda (checked-name)
-                   (equalp name checked-name))
-                 checked-attached-objects-of))
-         (object-directly-attached-p (object other-object)
-           (with-slots (attached-objects) object
-             (some (lambda (attached-object-name)
-                     (equalp attached-object-name (btr:name other-object)))
-                   (mapcar #'car attached-objects)))))
-    
-  (defmethod object-attached ((object item) (other-object item) &key)
+  (defmethod object-attached ((object item) (other-object item)
+                              &key checked-attached-objects-of)
     (with-slots (attached-objects) object
       (cond (;; If the `other-object' is directly attached to `object'
-             ;; return T and empty the list `checked-attached-object-of'.
+             ;; return T.
              (object-directly-attached-p object other-object)
-             (setf checked-attached-objects-of nil)
              (return-from object-attached T))
             (t
              ;; Otherwise, it will be checked if `other-object' is
              ;; attached to any attached object of `object' meaning
              ;; that an indirect attachment might exist e.g.:
              ;;    `object' <-> another-object <-> `other-object'
-             (push (btr:name object) checked-attached-objects-of)
-             (setf checked-all-attachments T)
-             (loop for attachment in attached-objects do
-               (unless (already-checked-object-p (car attachment))
-                 (setf checked-all-attachments NIL)
-                 (when (object-attached (btr:object
-                                         btr:*current-bullet-world*
-                                         (car attachment))
-                                        other-object)
-                   (setf checked-attached-objects-of nil)
-                   (return-from object-attached T))))
-             ;; If all attached objects were checked and no indirect
-             ;; attachment from `other-object' to `object' were found,
-             ;; we empty the list `checked-attached-object-of' and
-             ;; return NIL.
-             (when (and checked-all-attachments
-                        (equalp (last checked-attached-objects-of)
-                                (btr:name object)))
-               (setf checked-attached-objects-of nil)
-               (return-from object-attached NIL))))))))
+             (let ((checked-all-attachments T))
+               (loop for attachment in attached-objects do
+                 (unless (find (car attachment)
+                               checked-attached-objects-of
+                               :test #'equalp)
+                   (setf checked-all-attachments NIL)
+                   (when (object-attached
+                          (btr:object
+                           btr:*current-bullet-world*
+                           (car attachment))
+                          other-object
+                          :checked-attached-objects-of
+                          (append checked-attached-objects-of
+                                  (list (btr:name object))))
+                     (return-from object-attached T))))
+               ;; If all attached objects were checked and no indirect
+               ;; attachment from `other-object' to `object' were found,
+               ;; return NIL.
+               (when checked-all-attachments
+                 (return-from object-attached NIL))))))))
 
 ;;;;;;;;;;;;;;;;;;;;; SPAWNING MESH AND PRIMITIVE-SHAPED ITEMS ;;;;;;;;;;;;
 

--- a/cram_3d_world/cram_bullet_reasoning/src/items.lisp
+++ b/cram_3d_world/cram_bullet_reasoning/src/items.lisp
@@ -265,6 +265,52 @@ it is possible to change the pose of its attachments when its pose changes."
                 (setf already-moved '()))))
         (call-next-method))))
 
+(let ((checked-attached-objects-of '())
+      (checked-all-attachments T))
+  
+  (flet ((already-checked-object-p (name)
+           (some (lambda (checked-name)
+                   (equalp name checked-name))
+                 checked-attached-objects-of))
+         (object-directly-attached-p (object other-object)
+           (with-slots (attached-objects) object
+             (some (lambda (attached-object-name)
+                     (equalp attached-object-name (btr:name other-object)))
+                   (mapcar #'car attached-objects)))))
+    
+  (defmethod object-attached ((object item) (other-object item) &key)
+    (with-slots (attached-objects) object
+      (cond (;; If the `other-object' is directly attached to `object'
+             ;; return T and empty the list `checked-attached-object-of'.
+             (object-directly-attached-p object other-object)
+             (setf checked-attached-objects-of nil)
+             (return-from object-attached T))
+            (t
+             ;; Otherwise, it will be checked if `other-object' is
+             ;; attached to any attached object of `object' meaning
+             ;; that an indirect attachment might exist e.g.:
+             ;;    `object' <-> another-object <-> `other-object'
+             (push (btr:name object) checked-attached-objects-of)
+             (setf checked-all-attachments T)
+             (loop for attachment in attached-objects do
+               (unless (already-checked-object-p (car attachment))
+                 (setf checked-all-attachments NIL)
+                 (when (object-attached (btr:object
+                                         btr:*current-bullet-world*
+                                         (car attachment))
+                                        other-object)
+                   (setf checked-attached-objects-of nil)
+                   (return-from object-attached T))))
+             ;; If all attached objects were checked and no indirect
+             ;; attachment from `other-object' to `object' were found,
+             ;; we empty the list `checked-attached-object-of' and
+             ;; return NIL.
+             (when (and checked-all-attachments
+                        (equalp (last checked-attached-objects-of)
+                                (btr:name object)))
+               (setf checked-attached-objects-of nil)
+               (return-from object-attached NIL))))))))
+
 ;;;;;;;;;;;;;;;;;;;;; SPAWNING MESH AND PRIMITIVE-SHAPED ITEMS ;;;;;;;;;;;;
 
 (defmethod add-object ((world bt-world) (type (eql :mesh)) name pose

--- a/cram_3d_world/cram_bullet_reasoning/src/objects.lisp
+++ b/cram_3d_world/cram_bullet_reasoning/src/objects.lisp
@@ -460,6 +460,10 @@ of the object should _not_ be updated. `grasp' is the type of grasp orientation.
 (defgeneric detach-all-objects (object)
   (:documentation "Removes all attachments form the list of attached objects of `object'."))
 
+(defgeneric object-attached (object other-object &key &allow-other-keys)
+  (:documentation "Returns something if `other-object' is attached to
+  `object', otherwise NIL."))
+
 (defmethod attach-object ((object-to-attach-to-name symbol) (object-name symbol)
                           &key attachment-type loose skip-removing-loose link grasp)
   "Attaches object named `object-name' to another object named `object-to-attach-to-name'."

--- a/cram_3d_world/cram_bullet_reasoning/src/robot-model-utils.lisp
+++ b/cram_3d_world/cram_bullet_reasoning/src/robot-model-utils.lisp
@@ -273,8 +273,19 @@ or other objects to which current object is attached."
                                           (find this-object-name
                                                 (btr:attached-objects object)
                                                 :key #'car)))
-                                      colliding-objects-without-robot)))
-                    colliding-objects-without-robot-and-attached-objects))
+                                      colliding-objects-without-robot))
+                         ;; remove all items which are indirectly
+                         ;; attached between each other
+                         (colliding-objects-without-robot-and-indirect-attached-objects
+                           (remove-if 
+                            (lambda (object)
+                              (some (lambda (attachment)
+                                      (btr:object-attached
+                                       (btr:object btr:*current-bullet-world* (car attachment))
+                                       object))
+                                    (btr:attached-objects object)))
+                            colliding-objects-without-robot-and-attached-objects)))
+                    colliding-objects-without-robot-and-indirect-attached-objects))
                 (attached-objects (get-robot-object)))))
 
 

--- a/cram_3d_world/cram_bullet_reasoning/src/robot-model.lisp
+++ b/cram_3d_world/cram_bullet_reasoning/src/robot-model.lisp
@@ -139,23 +139,21 @@
 (defgeneric (setf link-pose) (new-value robot-object name)
   (:documentation "Sets the pose of a link and all its children"))
 
-(defgeneric object-attached (robot-object object &key loose)
-  (:documentation "Returns the list of links `object' has been
-  attached to.")
-  (:method ((robot-object robot-object) (object object) &key loose)
-    (with-slots (attached-objects) robot-object
-      (values (mapcar #'attachment-link (remove-if-not
-                                         (if loose
-                                             #'attachment-loose
-                                             #'identity)
-                                         (car (cdr (assoc (name object) attached-objects
-                                                          :test #'equal)))))
-              (mapcar #'attachment-grasp (remove-if-not
-                                          (if loose
-                                              #'attachment-loose
-                                              #'identity)
-                                          (car (cdr (assoc (name object) attached-objects
-                                                           :test #'equal)))))))))
+(defmethod object-attached ((object robot-object) (other-object object) &key loose)
+  "Returns the list of links `other-object' has been attached to."
+  (with-slots (attached-objects) object
+    (values (mapcar #'attachment-link (remove-if-not
+                                       (if loose
+                                           #'attachment-loose
+                                           #'identity)
+                                       (car (cdr (assoc (name other-object) attached-objects
+                                                        :test #'equal)))))
+            (mapcar #'attachment-grasp (remove-if-not
+                                        (if loose
+                                            #'attachment-loose
+                                            #'identity)
+                                        (car (cdr (assoc (name other-object) attached-objects
+                                                         :test #'equal))))))))
 
 (defmethod attach-object ((robot-object robot-object) (obj object)
                           &key link loose grasp &allow-other-keys)

--- a/cram_demos/cram_boxy_assembly_demo/src/projection-demo.lisp
+++ b/cram_demos/cram_boxy_assembly_demo/src/projection-demo.lisp
@@ -387,7 +387,7 @@
          (base-right-side-left-hand-pose
            `((,base-x 0.7 0) (0 0 0 1)))
          (base-very-right-side-left-hand-pose
-           `((,(- base-x 0.2) 0.65 0) (0 0 0 1))))
+           `((,(- base-x 0.18) 0.65 0) (0 0 0 1))))
 
     (urdf-proj:with-projected-robot
       ;; 1
@@ -437,7 +437,7 @@
                   :window-thread)
 
       ;; 10
-      (go-connect :top-wing  base-somewhat-left-side-left-hand-pose
+      (go-connect :top-wing  base-left-side-left-hand-pose
                   :holder-plane-vertical base-left-side-left-hand-pose
                   ;; or `((,(- *base-x* 0.00) 1.45 0) (0 0 0 1))
                   :vertical-attachment)

--- a/cram_demos/cram_boxy_assembly_demo/src/projection-demo.lisp
+++ b/cram_demos/cram_boxy_assembly_demo/src/projection-demo.lisp
@@ -195,6 +195,7 @@
                   spawning-data)))
 
     (btr:attach-object 'motor-grill 'underbody)
+    (btr:attach-object 'holder-top-wing 'top-wing :loose T)
 
     objects))
 


### PR DESCRIPTION
[Trello](https://trello.com/c/tCCJBPI5/383-attachments-in-cramprojectiondemos-assembly-demo-when-we-pick-up-the-plane-a-bolt-is-in-collision-with-the-chassis-actually-they)