### PR TITLE
Costmap and Marker Visualization for rviz updated

### DIFF
--- a/cram_3d_world/cram_bullet_reasoning/src/debug-window.lisp
+++ b/cram_3d_world/cram_bullet_reasoning/src/debug-window.lisp
@@ -216,5 +216,5 @@ It is built from 3 rigid bodies of primitive box shape.
 (defmethod costmap:on-visualize-costmap opengl ((map costmap:location-costmap))
   (add-costmap-function-object map))
 
-(defmethod costmap:on-visualize-costmap-sample opengl ((point cl-transforms:3d-vector))
+(defmethod costmap:on-visualize-costmap-sample opengl ((point cl-transforms:3d-vector) &key)
   (add-costmap-sample-object point))

--- a/cram_common/cram_location_costmap/src/location-costmap.lisp
+++ b/cram_common/cram_location_costmap/src/location-costmap.lisp
@@ -113,7 +113,7 @@
     name))
 
 (define-hook on-visualize-costmap (costmap))
-(define-hook on-visualize-costmap-sample (point))
+(define-hook on-visualize-costmap-sample (point &key &allow-other-keys))
 
 (defmethod get-cost-map ((map location-costmap))
   "Returns the costmap matrix of `map', i.e. if not generated yet,
@@ -223,7 +223,7 @@ calls the generator functions and runs normalization."
                (y (+ (* row resolution) origin-y))
                (z (generate-height map x y))
                (point (cl-transforms:make-3d-vector x y z)))
-          (on-visualize-costmap-sample point)
+          (on-visualize-costmap-sample point :resolution resolution)
           (on-visualize-costmap map)
           point)))))
 

--- a/cram_common/cram_location_costmap/src/visualization.lisp
+++ b/cram_common/cram_location_costmap/src/visualization.lisp
@@ -209,7 +209,7 @@ respectively."
       (publish *location-costmap-publisher*
                markers))))
 
-(defun publish-point (point resolution &key (id))
+(defun publish-point (point resolution &key id)
   (let ((current-index 0))
     (when *marker-publisher*
       (publish *marker-publisher*


### PR DESCRIPTION
[Trello](https://trello.com/c/xSzfOnO2/384-fix-the-height-and-colors-of-the-costmap-visualization-in-rviz-and-make-the-sample-visualization-a-red-box-not-transpaternt)