### PR TITLE
Using a Queue to handle the sequence of Process Modules

### DIFF
--- a/cram_core/cram_process_modules/src/package.lisp
+++ b/cram_core/cram_process_modules/src/package.lisp
@@ -36,7 +36,8 @@
         #:alexandria)
   (:import-from #:cram-prolog def-fact-group <- prolog)
   (:shadowing-import-from #:cram-prolog fail)
-  (:import-from #:cram-utilities lazy-mapcar force-ll var-value)
+  (:import-from #:cram-utilities lazy-mapcar force-ll var-value
+                make-queue enqueue dequeue list-queue-contents)
   (:nicknames :cpm)
   (:export process-module name input feedback result
            status cancel priority caller

--- a/cram_core/cram_process_modules/src/process-module-protocol.lisp
+++ b/cram_core/cram_process_modules/src/process-module-protocol.lisp
@@ -53,6 +53,9 @@
          :initform (error "Process modules need a name.")
          :initarg :name)
    (input :reader input :documentation "Input fluent.")
+   (input-queue :reader input-queue
+                :documentation "Queue to manage multiple simultaneous
+                                inputs to the process module")
    (status :reader status
            :documentation "Status fluent. Possible status: 
                            :waiting :running :failed")
@@ -69,9 +72,11 @@
            (intern (concatenate
                     'string (symbol-name process-module-name)
                     "-" (symbol-name type)))))
-    (with-slots (name input status cancel caller)
+    (with-slots (name input input-queue status cancel caller)
         pm
       (setf input (make-fluent :name (make-fluent-name name :input)))
+      (setf input-queue (make-fluent :name (make-fluent-name name :input-queue)
+                                     :value (make-queue)))
       (setf status (make-fluent :name (make-fluent-name name :status)
                                 :value :offline))
       (setf cancel (make-fluent :name (make-fluent-name name :cancel)))

--- a/cram_core/cram_process_modules/src/process-module.lisp
+++ b/cram_core/cram_process_modules/src/process-module.lisp
@@ -122,29 +122,46 @@
 
 (defmethod pm-execute ((pm process-module) input &key (task *current-task*))
   (with-slots ((input-fluent input)
+               name
+               input-queue
                status result caller
                execute-lock) pm
-    (retry-after-suspension
-      (unwind-protect
-           (progn
-             (sb-thread:with-mutex (execute-lock)
-               (when (eq (value status) :running)
-                 (warn "Process module ~a already processing input. Waiting for it to become free."
-                       pm)
-                 (wait-for (not (eq status :running))))    
-               (setf (value caller) task)
-               (setf (value input-fluent) input)
-               ;; Wait for the input fluent to be cleared again. That indicates
-               ;; that the process module started processing it. Please note
-               ;; that waiting for the status to become :running can lead to
-               ;; race conditions if the process module immediately returns.
-               (wait-for (not input-fluent)))
-             (wait-for (not (eq status :running)))
-             (when (eq (value status) :failed)
-               (error (value result)))
-             (apply #'values (value result)))
-        (pm-cancel pm)))))
-
+    (let* ((unique-name (gensym (string name)))
+           (top-of-queue-fl (eq (fl-funcall
+                                 #'car
+                                 (fl-funcall
+                                  #'list-queue-contents
+                                  input-queue))
+                                unique-name)))
+      (enqueue unique-name (value input-queue))
+      (pulse input-queue)
+      (retry-after-suspension
+        (unwind-protect
+             (progn
+               (wait-for top-of-queue-fl)
+               (sb-thread:with-mutex (execute-lock)
+                 (when (eq (value status) :running)
+                   (warn
+                    "Process module ~a already processing input. Waiting for it to become free."
+                         pm)
+                   (wait-for  (not (eq status :running))))
+                 (setf (value caller) task)
+                 (setf (value input-fluent) input)
+                 ;; Wait for the input fluent to be cleared again. That indicates
+                 ;; that the process module started processing it. Please note
+                 ;; that waiting for the status to become :running can lead to
+                 ;; race conditions if the process module immediately returns.
+                 (wait-for (not input-fluent)))
+               (wait-for (not (eq status :running)))
+               (let ((result-value (value result))
+                     (result-status (value status)))
+                 (dequeue (value input-queue))
+                 (pulse input-queue)
+                 (when (eq result-status :failed)
+                   (error result-value))
+               (apply #'values result-value)))
+          (pm-cancel pm))))))
+  
 (defmethod pm-cancel ((pm process-module))
   (setf (value (slot-value pm 'cancel)) t)
   ;; (wait-for (not (eq (slot-value pm 'status) :running)))

--- a/cram_core/cram_process_modules/test/process-module-tests.lisp
+++ b/cram_core/cram_process_modules/test/process-module-tests.lisp
@@ -185,3 +185,31 @@
                                 :designators (list designator))))))
     (assert-eq :ok execute-result)
     (assert-eq :ok monitor-result)))
+
+(define-test execution-order.1
+  (let* ((result nil)
+        (designator1 (desig:make-designator :test (lambda () (push 1 result))))
+        (designator2 (desig:make-designator :test (lambda () (push 2 result))))
+        (designator3 (desig:make-designator :test (lambda () (push 3 result)))))
+    (cpl:top-level
+      (with-process-modules-running (test-process-module)
+        (cpl:par
+          (pm-execute 'test-process-module designator1)
+          (progn 
+            (cpl:sleep 0.1)
+            (pm-execute 'test-process-module designator2))
+          (pm-execute 'test-process-module designator3))))
+    (assert-equal '(2 3 1) result)))
+
+(define-test execution-order.2
+  (let* ((result nil)
+        (designator1 (desig:make-designator :test (lambda () (push 1 result))))
+        (designator2 (desig:make-designator :test (lambda () (push 2 result))))
+        (designator3 (desig:make-designator :test (lambda () (push 3 result)))))
+    (cpl:top-level
+      (with-process-modules-running (test-process-module)
+        (cpl:par
+          (pm-execute 'test-process-module designator1)
+          (pm-execute 'test-process-module designator2)
+          (pm-execute 'test-process-module designator3))))
+    (assert-equal '(3 2 1) result)))


### PR DESCRIPTION
[Card](https://trello.com/c/3ugAh1uN/394-implement-pm-execute-with-input-queue)
### Changes
1. Added a slot to the process modules which initializes the queue
2. The values in the queues are unique IDs(gensyms) for each waiting pm-execute
3. The execution starts when the head of the queue has the same value as the unique ID
4. Pulsing the queues explicitly (tried doing the setf and equalp method as discussed in our meeting but the comparison still results in true [unless I specifically do this -> `(equalp ?queue (enqueue-return-q val ?queue))`, where enqueue-return-q is the queue object returned after enqueueing, but this is only because the order of evaluation, but normally during setf enqueue happens before testing so the test always return true there])
5. Added test cases to check the execution order