### PR TITLE
Fix typo in code

### DIFF
--- a/cram_3d_world/cl_bullet/src/constraints.cpp
+++ b/cram_3d_world/cl_bullet/src/constraints.cpp
@@ -125,7 +125,7 @@ extern "C"
 
   double getMotorTargetVelocity(/*const*/ btHingeConstraint *hinge)
   {
-    return hinge->getMotorTargetVelosity() / bulletWorldScalingFactor;
+    return hinge->getMotorTargetVelocity() / bulletWorldScalingFactor;
   }
 
   void setMotorTarget(btHingeConstraint *hinge, double targetAngle, double dt)


### PR DESCRIPTION
There was a typo in function getMotorTargetVelocity
in constraints.cpp.