### PR TITLE
Build CI for Noetic CRAM

### DIFF
--- a/.github/workflows/cram-build-ci.yml
+++ b/.github/workflows/cram-build-ci.yml
@@ -1,0 +1,57 @@
+name: ROS CI 20.04 | Build CRAM 
+
+on:
+   pull_request:
+    branches:
+      - noetic
+  
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    env:
+      ROS_CI_DESKTOP: "`lsb_release -cs`"  # e.g. [trusty|xenial|...]
+      CI_SOURCE_PATH: $(pwd)
+      ROSINSTALL_FILE: $CI_SOURCE_PATH/dependencies.rosinstall
+      CATKIN_OPTIONS: $CI_SOURCE_PATH/catkin.options
+      ROS_PARALLEL_JOBS: '-j8 -l6'
+      # Set the python path manually to include /usr/-/python3/dist-packages
+      # as this is where apt-get installs python packages.
+      PYTHONPATH: $PYTHONPATH:/usr/lib/python3/dist-packages:/usr/local/lib/python3/dist-packages
+      ROS_DISTRO: noetic
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install ROS
+        run: |
+            sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
+            sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+            sudo apt-get update -qq
+            sudo apt-get install dpkg
+            sudo apt-get install -y python3-catkin-tools python3-catkin-pkg
+            sudo apt-get install -y python3-rosdep python3-wstool
+            sudo apt-get install -y libboost-dev
+            sudo apt-get install -y libyaml-cpp-dev
+            sudo apt-get install -y ros-cmake-modules
+            sudo apt-get install -y ros-$ROS_DISTRO-nodelet-core
+            sudo apt-get install -y ros-$ROS_DISTRO-roscpp
+            sudo apt-get install -y ros-$ROS_DISTRO-roslint
+            sudo apt-get install -y ros-$ROS_DISTRO-std-msgs
+            sudo apt-get install -y ros-$ROS_DISTRO-roslisp-repl
+            sudo apt-get install -y libassimp-dev
+            sudo apt-get install -y libbullet-dev 
+            source /opt/ros/$ROS_DISTRO/setup.bash
+            # Prepare rosdep to install dependencies.
+            sudo rosdep init
+            rosdep update --include-eol-distros  # Support EOL distros.
+      - name: building CRAM
+        run: |
+          source /opt/ros/$ROS_DISTRO/setup.bash
+          mkdir -p ~/catkin_ws/src
+          cd ~/catkin_ws
+          catkin build
+          source devel/setup.bash
+          # echo "::warning $CI_SOURCE_PATH"
+          # echo "::warning `ls -l`"
+          cd src
+          ln -s ~/work  # $CI_SOURCE_PATH
+          cd ..
+          catkin build


### PR DESCRIPTION
Every time when something is PR on the branch noetic, the ci will build automatically cram. This will help us to check if there is any problem in a clean environment.