### PR TITLE
Add function to reset bullet window

### DIFF
--- a/cram_3d_world/cram_bullet_reasoning_utilities/src/package.lisp
+++ b/cram_3d_world/cram_bullet_reasoning_utilities/src/package.lisp
@@ -36,6 +36,7 @@
   (:export
    ;; vis-tools.lisp
    #:visualize-designator-costmaps #:visualize-gripper
+   #:reset-debug-window
    ;; object-database.lisp
    #:scenario-objects-init-pose #:scenario-objects-default-color #:scenario-object-color
    #:scenario-object-shape #:scenario-object-extra-attributes

--- a/cram_3d_world/cram_bullet_reasoning_utilities/src/vis-tools.lisp
+++ b/cram_3d_world/cram_bullet_reasoning_utilities/src/vis-tools.lisp
@@ -85,3 +85,16 @@
                        `(and (cram-robot-interfaces:robot ?robot)
                              (cram-robot-interfaces:standard<-particular-gripper-transform
                               ?robot ?transform)))))))))))))
+
+(defun reset-debug-window ()
+  "Terminates debug-window thread and launches a new one."
+  (let ((thread (find "Debug window"
+                      (sb-thread:list-all-threads)
+                      :key 'sb-thread:thread-name
+                      :test 'string=)))
+    (when thread
+      (sb-thread:terminate-thread thread)))
+  (when btr:*debug-window*
+    (cl-bullet-vis:close-window btr:*debug-window*))
+  (sleep 1)
+  (btr:add-debug-window btr:*current-bullet-world*))


### PR DESCRIPTION
Adds convenient function to reset the bullet window when it's frozen. Kills the thread, closes the window and opens a new one.
Call from your repl with `(btr-utils:reset-debug-window)`