### PR TITLE
Fix bullet-tutorial launchfile issue #246

### DIFF
--- a/cram_tutorials/cram_bullet_world_tutorial/launch/world.launch
+++ b/cram_tutorials/cram_bullet_world_tutorial/launch/world.launch
@@ -7,7 +7,7 @@
 
   <!-- kitchen URDF -->
   <param name="kitchen_description"
-         command="$(find xacro)/xacro.py '$(find iai_kitchen)/urdf_obj/iai_kitchen_python.urdf.xacro'"/>
+         command="$(find xacro)/xacro '$(find iai_kitchen)/urdf_obj/iai_kitchen_python.urdf.xacro'"/>
   <node pkg="joint_state_publisher" type="joint_state_publisher"
         name="joint_state_publisher" output="screen">
     <remap from="robot_description" to="kitchen_description"/>
@@ -35,7 +35,7 @@
   <!-- PR2 URDF -->
   <group if="$(arg upload)">
     <param name="robot_description"
-           command="$(find xacro)/xacro.py
+           command="$(find xacro)/xacro
                     '$(find pr2_description)/robots/pr2.urdf.xacro'"/>
   </group>
 


### PR DESCRIPTION
This updates the bullet tutorial launchfile for noetic. The corresponding urdf already work for noetic, so it's just the .py suffix really.  