### PR TITLE
Noetic

### DIFF
--- a/cram_3d_world/cram_urdf_environment_manipulation/src/plans.lisp
+++ b/cram_3d_world/cram_urdf_environment_manipulation/src/plans.lisp
@@ -29,6 +29,10 @@
 
 (in-package :env-man)
 
+(defparameter *detect-gripper-slip* T
+  "When opening/closing a container, detect if gripper joint falls below
+a threshold (if T) to signal a failure.")
+
 (defun manipulate-container (&key
                                ((:type ?type))
                                ((:arm ?arm))
@@ -129,43 +133,51 @@
   ;;;;;;;;;;;;;;;;;;;;;; MANIPULATING ;;;;;;;;;;;;;;;;;;;;;;;
   (roslisp:ros-info (environment-manipulation manipulate-container)
                     "Manipulating")
-  (cpl:pursue
-    (cpl:with-failure-handling
-        ((common-fail:manipulation-low-level-failure (e)
-           (roslisp:ros-warn (env-plans manipulate)
-                             "Manipulation messed up: ~a~%Failing."
-                             e)
-           ;; (return)
-           ))
-      (let ((?push-or-pull
-              (if (eq ?type :opening)
-                  :pulling
-                  :pushing))
-            (?goal
-              `(cpoe:tool-frames-at ,?left-manipulate-poses ,?right-manipulate-poses)))
-        (exe:perform
-         (desig:an action
-                   (type ?push-or-pull)
-                   (object (desig:an object (name ?environment-name)))
-                   (container-object ?container-designator)
-                   (link ?link-name)
-                   (desig:when ?absolute-distance
-                     (distance ?absolute-distance))
-                   (desig:when (eq ?arm :left)
-                     (left-poses ?left-manipulate-poses))
-                   (desig:when (eq ?arm :right)
-                     (right-poses ?right-manipulate-poses))
-                   (goal ?goal)))))
-    (cpl:seq
-      (exe:perform
-       (desig:an action
-                 (type monitoring-joint-state)
-                 (gripper ?arm)))
-      ;; sleep for half a second,
-      ;; maybe the action is nearly finished, so there is no need to fail
-      (cpl:sleep 1)
-      (cpl:fail 'common-fail:gripper-closed-completely
-                :description "Handle slipped")))
+  (let* ((?push-or-pull
+           (if (eq ?type :opening)
+               :pulling
+               :pushing))
+         (?goal
+           `(cpoe:tool-frames-at ,?left-manipulate-poses ,?right-manipulate-poses))
+         (manipulation-action
+           (desig:an action
+                     (type ?push-or-pull)
+                     (object (desig:an object (name ?environment-name)))
+                     (container-object ?container-designator)
+                     (link ?link-name)
+                     (desig:when ?absolute-distance
+                       (distance ?absolute-distance))
+                     (desig:when (eq ?arm :left)
+                       (left-poses ?left-manipulate-poses))
+                     (desig:when (eq ?arm :right)
+                       (right-poses ?right-manipulate-poses))
+                     (goal ?goal))))
+    (if *detect-gripper-slip*
+        ;; monitor gripper joint to detect if the handle slipped out of the gripper
+        (cpl:pursue
+         (cpl:with-failure-handling
+             ((common-fail:manipulation-low-level-failure
+               (e)
+               (roslisp:ros-warn (env-plans manipulate)
+                                 "Manipulation messed up: ~a~%Failing." e)))
+           (exe:perform manipulation-action))
+         (cpl:seq
+          (exe:perform
+           (desig:an action
+                     (type monitoring-joint-state)
+                     (gripper ?arm)))
+          ;; sleep for two seconds,
+          ;; maybe the action is nearly finished, so there is no need to fail
+          (cpl:sleep 2)
+          (cpl:fail 'common-fail:gripper-closed-completely
+                    :description "Handle slipped")))
+        ;; in unreal the gripper wiggles so much it falsely detects slipping
+        (cpl:with-failure-handling
+            ((common-fail:manipulation-low-level-failure
+              (e)
+              (roslisp:ros-warn (env-plans manipulate)
+                                "Manipulation messed up: ~a~%Failing." e)))
+          (exe:perform manipulation-action))))
 
   (when (and joint-name)
     (cram-occasions-events:on-event


### PR DESCRIPTION
Disable gripper-slip detection when handling containers in Unreal.
`(setf env-man::*detect-gripper-slip* NIL)`