### PR TITLE
[cram_language] update of the sleep function

### DIFF
--- a/cram_core/cram_language/src/utils.lisp
+++ b/cram_core/cram_language/src/utils.lisp
@@ -79,6 +79,7 @@
   (/ (float a 1.0d0) (float b 1.0d0)))
 
 (defun sleep* (seconds)
+   (common-lisp:sleep seconds)
   ;; (let ((seconds (coerce seconds 'double-float)))
   ;;   (declare (double-float seconds))
   ;;   #+nil (declare (optimize speed))


### PR DESCRIPTION
The special handling was necessary for older versions of SBCL that weren't using deadlines, Now it's finished, so no need to use custom deadlines.