### PR TITLE
added missing dependencies 

### DIFF
--- a/cram_common/cram_occupancy_grid_costmap/cram-occupancy-grid-costmap.asd
+++ b/cram_common/cram_occupancy_grid_costmap/cram-occupancy-grid-costmap.asd
@@ -35,7 +35,8 @@
                cram-robot-interfaces
                roslisp-utilities
                roslisp
-               nav_msgs-msg)
+               nav_msgs-msg
+               cram-manipulation-interfaces)
   :components
   ((:module "src"
     :components

--- a/cram_core/cram_executive/cram-executive.asd
+++ b/cram_core/cram_executive/cram-executive.asd
@@ -38,7 +38,8 @@
                :cram-language
                :cram-designators
                :cram-process-modules
-               :cram-occasions-events)
+               :cram-occasions-events
+               :roslisp)
 
   :components
   ((:module "src"


### PR DESCRIPTION
For cram_executive.asd and cram_occupancy_grid_costmap.asd that were noticed when updating the Intermediate cram tutorials. 