### PR TITLE
[objects] Fix unidirectional-attach overwrite

### DIFF
--- a/cram_demos/cram_object_knowledge/src/household.lisp
+++ b/cram_demos/cram_object_knowledge/src/household.lisp
@@ -156,8 +156,7 @@
     (member ?object-type (:knife :fork :spoon :cutlery :spatula :weisswurst
 			  :bread :big-knife))))
 
-(def-fact-group attachment-knowledge (man-int:unidirectional-attachment)
-
+(def-fact-group popcorn-attachment-knowledge (man-int:unidirectional-attachment)
   (<- (man-int:unidirectional-attachment ?attachment-type)
     (member ?attachment-type (:popcorn-pot-lid-attachment))))
 

--- a/cram_demos/cram_object_knowledge/src/retail.lisp
+++ b/cram_demos/cram_object_knowledge/src/retail.lisp
@@ -70,7 +70,7 @@
   (<- (man-int:object-type-direct-subtype :retail-bottle-flat ?item-type)
     (member ?item-type (:balea-bottle :denkmit-entkalker :kuehne-essig-essenz))))
 
-(def-fact-group attachment-knowledge (man-int:unidirectional-attachment)
+(def-fact-group basket-attachment-knowledge (man-int:unidirectional-attachment)
   (<- (man-int:unidirectional-attachment ?attachment-type)
     (member ?attachment-type (:in-basket-front :in-basket-back :in-basket))))
 


### PR DESCRIPTION
The files for retail and household each define the fact group `attachment-knowledge`. They overwrite the other, depending on the order of compilation. This PR renames the fact groups.